### PR TITLE
chore(release): prepare 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1 - 2026-08-27
+
+- Add CI, security, Hex, HexDocs, and license badges to the project README.
+- Update the installation example for the 0.1.1 release.
+
 ## 0.1.0 - 2026-08-27
 
 - Add an embeddable Phoenix LiveView process map and collapsible runtime tree.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # BeamConsole
 
+[![CI](https://github.com/ccarvalho-eng/beam_console/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ccarvalho-eng/beam_console/actions/workflows/ci.yml)
+[![Security](https://github.com/ccarvalho-eng/beam_console/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/ccarvalho-eng/beam_console/actions/workflows/security.yml)
+[![Hex.pm](https://img.shields.io/hexpm/v/beam_console.svg)](https://hex.pm/packages/beam_console)
+[![HexDocs](https://img.shields.io/badge/hex-docs-714a9f.svg)](https://hexdocs.pm/beam_console)
+[![License](https://img.shields.io/hexpm/l/beam_console.svg)](https://github.com/ccarvalho-eng/beam_console/blob/main/LICENSE)
+
 BeamConsole is an embeddable, read-only process flight recorder and process map for Phoenix and BEAM applications. It makes supervision, process relationships, lifecycle changes, per-process activity, and node-wide runtime health visible without application-specific instrumentation.
 
 ## Installation
@@ -9,7 +15,7 @@ Add BeamConsole to a Phoenix application:
 ```elixir
 def deps do
   [
-    {:beam_console, "~> 0.1.0"}
+    {:beam_console, "~> 0.1.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BeamConsole.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ccarvalho-eng/beam_console"
-  @version "0.1.0"
+  @version "0.1.1"
 
   def project do
     [


### PR DESCRIPTION
## Summary

- add CI, security, Hex version, HexDocs, and license badges to the README
- bump BeamConsole to 0.1.1 and refresh the installation example
- document the patch release in the changelog

## Release

Prepares `v0.1.1` for publication on GitHub and Hex.
