### PR TITLE
feat: add resource-aware recording control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+## 0.4.0 - 2026-08-27
+
+- Add restart-safe operator recording control shared by the collector and lifecycle recorder.
+- Stop opt-in always-on background scans after recording is paused and the final viewer disconnects.
+- Keep connected dashboards live while lifecycle recording is paused.
+- Cancel deferred lifecycle reconciliation on pause without terminating an in-flight runtime scan.
+
 ## 0.3.0 - 2026-08-27
 
 - Keep always-on lifecycle recording active across zero-viewer and runtime-service restart windows.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add BeamConsole to a Phoenix application:
 ```elixir
 def deps do
   [
-    {:beam_console, "~> 0.3.0"}
+    {:beam_console, "~> 0.4.0"}
   ]
 end
 ```
@@ -55,6 +55,9 @@ end
 
 status = BeamConsole.Recorder.status()
 events = BeamConsole.Recorder.events(limit: 100)
+
+paused = BeamConsole.Recording.pause()
+resumed = BeamConsole.Recording.resume()
 ```
 
 Call `BeamConsole.unsubscribe/0` when a long-lived manual subscriber no longer needs updates. Subscribers are also removed automatically when their process terminates.
@@ -71,7 +74,7 @@ Applications are grouped into host, dependencies, OTP, and tooling categories. E
 
 ## Recording model
 
-The default `:subscribers` mode records while at least one BeamConsole page is connected. The header control pauses and resumes recording explicitly. Retained samples remain bounded by age, item count, chart point count, and estimated bytes.
+The default `:subscribers` mode records while at least one BeamConsole page is connected. The header control pauses and resumes lifecycle recording explicitly. A connected dashboard continues receiving live runtime samples while recording is paused. Retained samples remain bounded by age, item count, chart point count, and estimated bytes.
 
 To begin recording when the application starts, even before anyone opens the page:
 
@@ -80,7 +83,9 @@ config :beam_console, :recorder,
   mode: :always
 ```
 
-In `:always` mode, sampling and lifecycle recording remain active with zero connected pages. The collector and recorder both derive their demand from this mode, so ordinary subscriber disconnects and supervised collector or recorder restarts do not silently return recording to subscriber-only behavior. An explicit operator pause still takes precedence until recording is resumed.
+In `:always` mode, sampling and lifecycle recording remain active with zero connected pages. The collector and recorder both derive their demand from this mode, so ordinary subscriber disconnects and supervised collector or recorder restarts do not silently return recording to subscriber-only behavior. An explicit operator pause takes precedence: lifecycle watches stop immediately, and background sampling stops when no viewer remains. The shared pause state survives independent collector and recorder restarts until recording is resumed; a full application restart restores the configured default.
+
+One runtime scan already in flight when recording is paused may still complete and update the latest snapshot. It cannot restart a zero-viewer background scan loop. Manual refresh remains a bounded one-shot, while recorder-driven reconciliation is suppressed until recording resumes.
 
 Lifecycle recording is observational rather than a lossless trace. Sampling gaps, partial supervision traversal, process limits, watch limits, and dropped history are surfaced in the interface instead of being hidden.
 

--- a/lib/beam_console/application.ex
+++ b/lib/beam_console/application.ex
@@ -13,14 +13,18 @@ defmodule BeamConsole.Application do
     recorder_config = BeamConsole.Config.recorder()
 
     children = [
+      BeamConsole.Recording.Control,
       {Task.Supervisor, name: BeamConsole.TaskSupervisor},
       {BeamConsole.Lifecycle.Recorder,
-       config: recorder_config, refresh_requester: &BeamConsole.Collector.request_reconciliation/0},
+       config: recorder_config,
+       recording_control: BeamConsole.Recording.Control,
+       refresh_requester: &BeamConsole.Collector.request_reconciliation/0},
       {BeamConsole.Collector,
        lifecycle_recorder: BeamConsole.Lifecycle.Recorder,
+       recording_control: BeamConsole.Recording.Control,
        always_record?: recorder_config.mode == :always}
     ]
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: BeamConsole.Supervisor)
+    Supervisor.start_link(children, strategy: :rest_for_one, name: BeamConsole.Supervisor)
   end
 end

--- a/lib/beam_console/collector.ex
+++ b/lib/beam_console/collector.ex
@@ -16,10 +16,12 @@ defmodule BeamConsole.Collector do
   alias BeamConsole.Config
   alias BeamConsole.Diff
   alias BeamConsole.EntityId
-  alias BeamConsole.Lifecycle.Recorder, as: LifecycleRecorder
   alias BeamConsole.Lifecycle.DiffEvents
+  alias BeamConsole.Lifecycle.Recorder, as: LifecycleRecorder
   alias BeamConsole.ReasonSummary
   alias BeamConsole.Recorder.Frame
+  alias BeamConsole.Recording.Control, as: RecordingControl
+  alias BeamConsole.Recording.Status, as: RecordingStatus
   alias BeamConsole.Runtime.InternalProcesses
   alias BeamConsole.Runtime.Local
   alias BeamConsole.Snapshot
@@ -28,6 +30,9 @@ defmodule BeamConsole.Collector do
             runtime: Local,
             runtime_options: [],
             lifecycle_recorder: nil,
+            recording_control: nil,
+            recording_paused?: false,
+            recording_revision: 0,
             always_record?: false,
             recorder_gap?: false,
             recorder_epoch: nil,
@@ -54,6 +59,9 @@ defmodule BeamConsole.Collector do
           runtime: module(),
           runtime_options: keyword(),
           lifecycle_recorder: GenServer.server() | nil,
+          recording_control: GenServer.server() | nil,
+          recording_paused?: boolean(),
+          recording_revision: non_neg_integer(),
           always_record?: boolean(),
           recorder_gap?: boolean(),
           recorder_epoch: String.t(),
@@ -160,11 +168,17 @@ defmodule BeamConsole.Collector do
       |> Keyword.take(Config.runtime_keys())
       |> Keyword.merge(Keyword.get(options, :runtime_options, []))
 
+    recording_control = Keyword.get(options, :recording_control)
+    recording_status = register_recording_control(recording_control)
+
     state = %__MODULE__{
       name: Keyword.fetch!(options, :name),
       runtime: Keyword.get(options, :runtime, Local),
       runtime_options: runtime_options,
       lifecycle_recorder: Keyword.get(options, :lifecycle_recorder),
+      recording_control: recording_control,
+      recording_paused?: recording_status.paused?,
+      recording_revision: recording_status.revision,
       always_record?: Keyword.get(options, :always_record?, false),
       recorder_epoch: EntityId.build(:event, {:collector_epoch, make_ref()}),
       task_supervisor: Keyword.get(options, :task_supervisor, BeamConsole.TaskSupervisor),
@@ -182,7 +196,7 @@ defmodule BeamConsole.Collector do
       deactivate_lifecycle_recorder(state.lifecycle_recorder)
     end
 
-    {:ok, if(state.always_record?, do: request_scan(state), else: state)}
+    {:ok, if(effective_sampling_demand?(state), do: request_scan(state), else: state)}
   end
 
   @impl GenServer
@@ -227,7 +241,8 @@ defmodule BeamConsole.Collector do
   end
 
   def handle_call(:request_reconciliation, _from, state) do
-    {:reply, :ok, request_scan(state)}
+    next_state = if recording_demand?(state), do: request_scan(state), else: state
+    {:reply, :ok, next_state}
   end
 
   def handle_call({:changes_since, sequence}, _from, state) do
@@ -237,7 +252,8 @@ defmodule BeamConsole.Collector do
 
   @impl GenServer
   def handle_cast(:refresh, state) do
-    {:noreply, request_scan(state)}
+    next_state = if recording_demand?(state), do: request_scan(state), else: state
+    {:noreply, next_state}
   end
 
   @impl GenServer
@@ -312,6 +328,13 @@ defmodule BeamConsole.Collector do
       %Subscriber{monitor_ref: ^reference} -> {:noreply, remove_subscriber(state, subscriber)}
       _other -> {:noreply, state}
     end
+  end
+
+  def handle_info(
+        {RecordingControl, %RecordingStatus{} = status},
+        state
+      ) do
+    {:noreply, apply_recording_status(state, status)}
   end
 
   def handle_info(_message, state) do
@@ -407,14 +430,13 @@ defmodule BeamConsole.Collector do
     request_scan(%{state | pending_refresh?: false})
   end
 
-  defp schedule_after_scan(state)
-       when map_size(state.subscribers) > 0 or state.always_record? do
-    cancel_timer(state.tick_ref)
-    schedule_scan(%{state | tick_ref: nil}, state.interval)
-  end
-
   defp schedule_after_scan(state) do
-    state
+    if effective_sampling_demand?(state) do
+      cancel_timer(state.tick_ref)
+      schedule_scan(%{state | tick_ref: nil}, state.interval)
+    else
+      state
+    end
   end
 
   defp add_subscriber(state, subscriber) do
@@ -464,14 +486,14 @@ defmodule BeamConsole.Collector do
     state
   end
 
-  defp after_subscriber_removed(%{always_record?: false} = state) do
-    cancel_timer(state.tick_ref)
-    deactivate_lifecycle_recorder(state.lifecycle_recorder)
-    %{state | tick_ref: nil, pending_refresh?: false}
-  end
-
-  defp after_subscriber_removed(%{always_record?: true} = state) do
-    state
+  defp after_subscriber_removed(state) do
+    if background_sampling_demand?(state) do
+      state
+    else
+      cancel_timer(state.tick_ref)
+      deactivate_lifecycle_recorder(state.lifecycle_recorder)
+      %{state | tick_ref: nil, pending_refresh?: false}
+    end
   end
 
   defp notify_subscribers(state) do
@@ -563,7 +585,7 @@ defmodule BeamConsole.Collector do
     recorder = state.lifecycle_recorder
 
     if recorder_available?(recorder) do
-      if state.always_record? or map_size(state.subscribers) > 0 do
+      if recording_demand?(state) do
         LifecycleRecorder.activate(recorder)
       end
 
@@ -581,6 +603,72 @@ defmodule BeamConsole.Collector do
     else
       %{state | recorder_gap?: true}
     end
+  end
+
+  defp register_recording_control(nil) do
+    %RecordingStatus{paused?: false, revision: 0}
+  end
+
+  defp register_recording_control(control) do
+    RecordingControl.register(:collector, control)
+  end
+
+  defp apply_recording_status(
+         %{recording_revision: revision} = state,
+         %RecordingStatus{revision: incoming_revision}
+       )
+       when incoming_revision <= revision do
+    state
+  end
+
+  defp apply_recording_status(state, %RecordingStatus{paused?: true} = status) do
+    state = %{
+      state
+      | recording_paused?: true,
+        recording_revision: status.revision
+    }
+
+    if viewer_sampling_demand?(state) do
+      state
+    else
+      cancel_timer(state.tick_ref)
+      %{state | tick_ref: nil, pending_refresh?: false}
+    end
+  end
+
+  defp apply_recording_status(state, %RecordingStatus{paused?: false} = status) do
+    state = %{
+      state
+      | recording_paused?: false,
+        recording_revision: status.revision
+    }
+
+    ensure_demand_scan(state)
+  end
+
+  defp ensure_demand_scan(%{scan: nil, tick_ref: nil} = state) do
+    if effective_sampling_demand?(state), do: request_scan(state), else: state
+  end
+
+  defp ensure_demand_scan(state) do
+    state
+  end
+
+  defp effective_sampling_demand?(state) do
+    viewer_sampling_demand?(state) or background_sampling_demand?(state)
+  end
+
+  defp viewer_sampling_demand?(state) do
+    map_size(state.subscribers) > 0
+  end
+
+  defp background_sampling_demand?(state) do
+    state.always_record? and not state.recording_paused?
+  end
+
+  defp recording_demand?(state) do
+    not state.recording_paused? and
+      (state.always_record? or viewer_sampling_demand?(state))
   end
 
   defp activate_lifecycle_recorder(nil) do

--- a/lib/beam_console/lifecycle/recorder.ex
+++ b/lib/beam_console/lifecycle/recorder.ex
@@ -17,8 +17,8 @@ defmodule BeamConsole.Lifecycle.Recorder do
   alias BeamConsole.Lifecycle.Event
   alias BeamConsole.Lifecycle.Observation
   alias BeamConsole.Lifecycle.PendingExit
-  alias BeamConsole.Lifecycle.RefreshRequest
   alias BeamConsole.Lifecycle.Recorder.State
+  alias BeamConsole.Lifecycle.RefreshRequest
   alias BeamConsole.Lifecycle.Watch
   alias BeamConsole.ReasonSummary
   alias BeamConsole.Recorder.Config
@@ -26,6 +26,8 @@ defmodule BeamConsole.Lifecycle.Recorder do
   alias BeamConsole.Recorder.History
   alias BeamConsole.Recorder.Query
   alias BeamConsole.Recorder.Status
+  alias BeamConsole.Recording.Control, as: RecordingControl
+  alias BeamConsole.Recording.Status, as: RecordingStatus
 
   @type status :: Status.t()
   @type query_error :: {:error, {:invalid_query_options, term()}}
@@ -69,13 +71,13 @@ defmodule BeamConsole.Lifecycle.Recorder do
     GenServer.cast(server, :deactivate)
   end
 
-  @doc "Pauses recording until an operator explicitly resumes it."
+  @doc "Pauses recording through the configured authority until explicitly resumed."
   @spec pause(GenServer.server(), timeout()) :: Status.t()
   def pause(server \\ __MODULE__, timeout \\ 5_000) do
     GenServer.call(server, :pause, timeout)
   end
 
-  @doc "Resumes recording when subscriber or always-on demand is present."
+  @doc "Resumes through the configured authority when recording demand is present."
   @spec resume(GenServer.server(), timeout()) :: Status.t()
   def resume(server \\ __MODULE__, timeout \\ 5_000) do
     GenServer.call(server, :resume, timeout)
@@ -117,15 +119,20 @@ defmodule BeamConsole.Lifecycle.Recorder do
     system_clock = Keyword.get(options, :system_clock, &system_ms/0)
     refresh_timeout = refresh_timeout!(Keyword.get(options, :refresh_timeout, 250))
     refresh_requester = refresh_requester!(options)
+    recording_control = Keyword.get(options, :recording_control)
+    recording_status = register_recording_control(recording_control)
 
     state = %State{
       config: config,
       history: History.new(config),
+      recording_control: recording_control,
+      recording_revision: recording_status.revision,
       refresh_requester: refresh_requester,
       refresh_timeout: refresh_timeout,
       monotonic_clock: monotonic_clock,
       system_clock: system_clock,
-      demanded?: config.mode == :always
+      demanded?: config.mode == :always,
+      paused?: recording_status.paused?
     }
 
     {:ok, if(config.mode == :always, do: start_recording(state), else: state)}
@@ -138,14 +145,12 @@ defmodule BeamConsole.Lifecycle.Recorder do
   end
 
   def handle_call(:pause, _from, state) do
-    state = state |> flush_pending_events() |> Map.put(:paused?, true) |> stop_recording()
+    state = apply_operator_intent(state, true)
     {:reply, status_from_state(state), state}
   end
 
   def handle_call(:resume, _from, state) do
-    state = %{state | paused?: false}
-    state = if state.demanded?, do: start_recording(state), else: state
-    state = maybe_schedule_reconciliation(state)
+    state = apply_operator_intent(state, false)
     {:reply, status_from_state(state), state}
   end
 
@@ -237,7 +242,7 @@ defmodule BeamConsole.Lifecycle.Recorder do
         {:DOWN, monitor_ref, :process, _requester, _reason},
         %State{refresh_request: %{monitor_ref: monitor_ref} = request} = state
       ) do
-    outcome = if request.timed_out?, do: :error, else: request.outcome || :error
+    outcome = refresh_request_outcome(request)
     {:noreply, complete_refresh_request(state, outcome)}
   end
 
@@ -272,6 +277,13 @@ defmodule BeamConsole.Lifecycle.Recorder do
     {:noreply, maybe_start_refresh_request(state)}
   end
 
+  def handle_info(
+        {RecordingControl, %RecordingStatus{} = status},
+        state
+      ) do
+    {:noreply, apply_recording_status(state, status)}
+  end
+
   def handle_info(_message, state) do
     {:noreply, state}
   end
@@ -292,6 +304,87 @@ defmodule BeamConsole.Lifecycle.Recorder do
       {:error, _reason} = error ->
         {:reply, error, state}
     end
+  end
+
+  defp register_recording_control(nil) do
+    %RecordingStatus{paused?: false, revision: 0}
+  end
+
+  defp register_recording_control(control) do
+    RecordingControl.register(:recorder, control)
+  end
+
+  defp apply_recording_status(
+         %State{recording_revision: revision} = state,
+         %RecordingStatus{revision: incoming_revision}
+       )
+       when incoming_revision <= revision do
+    state
+  end
+
+  defp apply_recording_status(state, %RecordingStatus{paused?: true} = status) do
+    state
+    |> Map.put(:recording_revision, status.revision)
+    |> pause_recording()
+  end
+
+  defp apply_recording_status(state, %RecordingStatus{paused?: false} = status) do
+    state
+    |> Map.put(:recording_revision, status.revision)
+    |> resume_recording()
+  end
+
+  defp apply_operator_intent(%State{recording_control: nil} = state, true) do
+    pause_recording(state)
+  end
+
+  defp apply_operator_intent(%State{recording_control: nil} = state, false) do
+    resume_recording(state)
+  end
+
+  defp apply_operator_intent(state, paused?) do
+    status = set_authoritative_pause(state.recording_control, paused?)
+    state = %{state | recording_revision: max(state.recording_revision, status.revision)}
+
+    if paused?, do: pause_recording(state), else: resume_recording(state)
+  end
+
+  defp set_authoritative_pause(control, true) do
+    RecordingControl.pause(control)
+  end
+
+  defp set_authoritative_pause(control, false) do
+    RecordingControl.resume(control)
+  end
+
+  defp pause_recording(state) do
+    state
+    |> flush_pending_events()
+    |> Map.put(:paused?, true)
+    |> stop_recording()
+    |> cancel_reconciliation()
+  end
+
+  defp resume_recording(state) do
+    state = %{state | paused?: false}
+    state = if state.demanded?, do: start_recording(state), else: state
+    maybe_schedule_reconciliation(state)
+  end
+
+  defp cancel_reconciliation(%State{refresh_request: nil} = state) do
+    %{state | refresh_pending?: false, reconcile_scheduled?: false}
+  end
+
+  defp cancel_reconciliation(%State{refresh_request: request} = state) do
+    cancel_refresh_timeout(request.timeout_ref)
+    :ok = RefreshRequest.cancel(request.pid)
+
+    %{
+      state
+      | refresh_request: %{request | cancelled?: true},
+        refresh_pending?: false,
+        reconcile_scheduled?: false
+    }
   end
 
   defp validate_query_options(options, kind) when is_list(options) do
@@ -747,7 +840,8 @@ defmodule BeamConsole.Lifecycle.Recorder do
       monitor_ref: monitor_ref,
       timeout_ref: timeout_ref,
       outcome: nil,
-      timed_out?: false
+      timed_out?: false,
+      cancelled?: false
     }
 
     %{state | refresh_request: request}
@@ -789,7 +883,23 @@ defmodule BeamConsole.Lifecycle.Recorder do
     :ok
   end
 
+  defp refresh_request_outcome(%{cancelled?: true}) do
+    :cancelled
+  end
+
+  defp refresh_request_outcome(%{timed_out?: true}) do
+    :error
+  end
+
+  defp refresh_request_outcome(request) do
+    request.outcome || :error
+  end
+
   defp missed_reconciliation_increment(:ok) do
+    0
+  end
+
+  defp missed_reconciliation_increment(:cancelled) do
     0
   end
 

--- a/lib/beam_console/lifecycle/recorder/state.ex
+++ b/lib/beam_console/lifecycle/recorder/state.ex
@@ -13,6 +13,8 @@ defmodule BeamConsole.Lifecycle.Recorder.State do
 
   defstruct config: nil,
             history: nil,
+            recording_control: nil,
+            recording_revision: 0,
             refresh_requester: nil,
             refresh_timeout: 250,
             refresh_request: nil,
@@ -45,12 +47,15 @@ defmodule BeamConsole.Lifecycle.Recorder.State do
           monitor_ref: reference(),
           timeout_ref: reference(),
           outcome: :ok | :error | nil,
-          timed_out?: boolean()
+          timed_out?: boolean(),
+          cancelled?: boolean()
         }
 
   @type t :: %__MODULE__{
           config: Config.t(),
           history: History.t(),
+          recording_control: GenServer.server() | nil,
+          recording_revision: non_neg_integer(),
           refresh_requester: refresh_requester(),
           refresh_timeout: pos_integer(),
           refresh_request: refresh_request() | nil,

--- a/lib/beam_console/recorder.ex
+++ b/lib/beam_console/recorder.ex
@@ -17,13 +17,13 @@ defmodule BeamConsole.Recorder do
     LifecycleRecorder.status(server)
   end
 
-  @doc "Pauses process recording while preserving bounded in-memory history."
+  @doc "Pauses process recording through its configured authority while preserving history."
   @spec pause(GenServer.server()) :: Status.t()
   def pause(server \\ LifecycleRecorder) do
     LifecycleRecorder.pause(server)
   end
 
-  @doc "Resumes process recording when the configured demand mode allows it."
+  @doc "Resumes process recording through its configured authority when demand allows it."
   @spec resume(GenServer.server()) :: Status.t()
   def resume(server \\ LifecycleRecorder) do
     LifecycleRecorder.resume(server)

--- a/lib/beam_console/recording.ex
+++ b/lib/beam_console/recording.ex
@@ -1,0 +1,31 @@
+defmodule BeamConsole.Recording do
+  @moduledoc """
+  Coordinates operator control of BeamConsole recording demand.
+
+  Pausing removes lifecycle watches and suppresses opt-in always-on background
+  scans after the last viewer disconnects. Connected viewers continue receiving
+  live read-only runtime samples. Retained recorder history remains bounded and
+  available while recording is paused.
+  """
+
+  alias BeamConsole.Recording.Control
+  alias BeamConsole.Recording.Status
+
+  @doc "Pauses recording and zero-viewer background sampling."
+  @spec pause(GenServer.server(), timeout()) :: Status.t()
+  def pause(server \\ Control, timeout \\ 5_000) do
+    Control.pause(server, timeout)
+  end
+
+  @doc "Resumes recording according to the configured demand mode."
+  @spec resume(GenServer.server(), timeout()) :: Status.t()
+  def resume(server \\ Control, timeout \\ 5_000) do
+    Control.resume(server, timeout)
+  end
+
+  @doc "Returns the authoritative operator recording control state."
+  @spec status(GenServer.server(), timeout()) :: Status.t()
+  def status(server \\ Control, timeout \\ 5_000) do
+    Control.status(server, timeout)
+  end
+end

--- a/lib/beam_console/recording/control.ex
+++ b/lib/beam_console/recording/control.ex
@@ -1,0 +1,157 @@
+defmodule BeamConsole.Recording.Control do
+  @moduledoc """
+  Owns restart-safe operator recording intent for the BeamConsole application.
+
+  The process stores only a boolean pause state and a monotonic revision. The
+  collector and lifecycle recorder register as monitored consumers, receive the
+  current state during initialization, and receive later transitions as bounded
+  scalar messages. A child restart therefore converges without coupling the two
+  runtime services to each other.
+  """
+
+  use GenServer
+
+  alias BeamConsole.Recording.Status
+
+  @roles [:collector, :recorder]
+
+  defstruct status: %Status{paused?: false, revision: 0}, consumers: %{}, subscribers: %{}
+
+  @type role :: :collector | :recorder
+  @type consumer :: %{pid: pid(), monitor_ref: reference()}
+  @type t :: %__MODULE__{
+          status: Status.t(),
+          consumers: %{optional(role()) => consumer()},
+          subscribers: %{optional(pid()) => reference()}
+        }
+
+  @doc "Starts the recording control authority."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(options \\ []) do
+    name = Keyword.get(options, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, options, name: name)
+  end
+
+  @doc "Registers the calling runtime service and returns the current control state."
+  @spec register(role(), GenServer.server()) :: Status.t()
+  def register(role, server \\ __MODULE__) when role in @roles do
+    GenServer.call(server, {:register, role, self()})
+  end
+
+  @doc "Subscribes the calling process to authoritative recording-state transitions."
+  @spec subscribe(GenServer.server(), timeout()) :: Status.t()
+  def subscribe(server \\ __MODULE__, timeout \\ 5_000) do
+    GenServer.call(server, {:subscribe, self()}, timeout)
+  end
+
+  @doc "Pauses lifecycle recording and opt-in zero-viewer background sampling."
+  @spec pause(GenServer.server(), timeout()) :: Status.t()
+  def pause(server \\ __MODULE__, timeout \\ 5_000) do
+    GenServer.call(server, {:set_paused, true}, timeout)
+  end
+
+  @doc "Resumes lifecycle recording according to the configured demand mode."
+  @spec resume(GenServer.server(), timeout()) :: Status.t()
+  def resume(server \\ __MODULE__, timeout \\ 5_000) do
+    GenServer.call(server, {:set_paused, false}, timeout)
+  end
+
+  @doc "Returns the authoritative operator recording control state."
+  @spec status(GenServer.server(), timeout()) :: Status.t()
+  def status(server \\ __MODULE__, timeout \\ 5_000) do
+    GenServer.call(server, :status, timeout)
+  end
+
+  @impl GenServer
+  def init(_options) do
+    {:ok, %__MODULE__{}}
+  end
+
+  @impl GenServer
+  def handle_call({:register, role, consumer}, _from, state)
+      when role in @roles and is_pid(consumer) do
+    consumers = register_consumer(state.consumers, role, consumer)
+    {:reply, state.status, %{state | consumers: consumers}}
+  end
+
+  def handle_call({:subscribe, subscriber}, _from, state) when is_pid(subscriber) do
+    subscribers = register_subscriber(state.subscribers, subscriber)
+    {:reply, state.status, %{state | subscribers: subscribers}}
+  end
+
+  def handle_call({:set_paused, paused?}, _from, state) when is_boolean(paused?) do
+    if state.status.paused? == paused? do
+      {:reply, state.status, state}
+    else
+      status = %Status{paused?: paused?, revision: state.status.revision + 1}
+      broadcast(state.consumers, state.subscribers, status)
+      {:reply, status, %{state | status: status}}
+    end
+  end
+
+  def handle_call(:status, _from, state) do
+    {:reply, state.status, state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, monitor_ref, :process, pid, _reason}, state) do
+    consumers = remove_consumer(state.consumers, pid, monitor_ref)
+    subscribers = remove_subscriber(state.subscribers, pid, monitor_ref)
+    {:noreply, %{state | consumers: consumers, subscribers: subscribers}}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  defp register_consumer(consumers, role, consumer) do
+    case Map.get(consumers, role) do
+      %{pid: ^consumer} ->
+        consumers
+
+      previous ->
+        demonitor_consumer(previous)
+        monitor_ref = Process.monitor(consumer)
+        Map.put(consumers, role, %{pid: consumer, monitor_ref: monitor_ref})
+    end
+  end
+
+  defp demonitor_consumer(%{monitor_ref: monitor_ref}) do
+    Process.demonitor(monitor_ref, [:flush])
+    :ok
+  end
+
+  defp demonitor_consumer(nil) do
+    :ok
+  end
+
+  defp register_subscriber(subscribers, subscriber) do
+    case Map.fetch(subscribers, subscriber) do
+      {:ok, _monitor_ref} -> subscribers
+      :error -> Map.put(subscribers, subscriber, Process.monitor(subscriber))
+    end
+  end
+
+  defp broadcast(consumers, subscribers, status) do
+    Enum.each(consumers, fn {_role, %{pid: consumer}} ->
+      send(consumer, {__MODULE__, status})
+    end)
+
+    Enum.each(subscribers, fn {subscriber, _monitor_ref} ->
+      send(subscriber, {__MODULE__, status})
+    end)
+  end
+
+  defp remove_consumer(consumers, pid, monitor_ref) do
+    Map.reject(consumers, fn {_role, consumer} ->
+      consumer.pid == pid and consumer.monitor_ref == monitor_ref
+    end)
+  end
+
+  defp remove_subscriber(subscribers, pid, monitor_ref) do
+    case Map.get(subscribers, pid) do
+      ^monitor_ref -> Map.delete(subscribers, pid)
+      _other -> subscribers
+    end
+  end
+end

--- a/lib/beam_console/recording/status.ex
+++ b/lib/beam_console/recording/status.ex
@@ -1,0 +1,11 @@
+defmodule BeamConsole.Recording.Status do
+  @moduledoc "Describes the authoritative operator recording control state."
+
+  @enforce_keys [:paused?, :revision]
+  defstruct paused?: false, revision: 0
+
+  @type t :: %__MODULE__{
+          paused?: boolean(),
+          revision: non_neg_integer()
+        }
+end

--- a/lib/beam_console_web/components/shell_components.ex
+++ b/lib/beam_console_web/components/shell_components.ex
@@ -10,7 +10,8 @@ if Code.ensure_loaded?(Phoenix.Component) do
     attr(:filter_form, :map, required: true)
     attr(:tab, :atom, required: true)
     attr(:tab_paths, :map, required: true)
-    attr(:recorder_activity, :atom, required: true)
+    attr(:recording_paused?, :boolean, required: true)
+    attr(:recording_control_available?, :boolean, required: true)
     attr(:refresh_pending?, :boolean, default: false)
 
     @doc "Renders the dashboard header with tabs, recording controls, refresh, and theme selection."
@@ -87,7 +88,11 @@ if Code.ensure_loaded?(Phoenix.Component) do
             aria-live="polite"
             aria-atomic="true"
           >
-            {status_announcement(@status_state)}
+            {status_announcement(
+              @status_state,
+              @recording_paused?,
+              @recording_control_available?
+            )}
           </span>
 
           <.form
@@ -119,18 +124,14 @@ if Code.ensure_loaded?(Phoenix.Component) do
 
           <button
             id="beam-console-recorder-control"
-            class={["beam-console-icon-button", @recorder_activity == :recording && "is-recording"]}
+            class={["beam-console-icon-button", not @recording_paused? && "is-recording"]}
             phx-click="toggle_recording"
-            aria-label={
-              if(@recorder_activity == :recording, do: "Pause recording", else: "Resume recording")
-            }
-            data-tooltip={
-              if(@recorder_activity == :recording, do: "Pause recording", else: "Resume recording")
-            }
-            aria-pressed={if(@recorder_activity == :recording, do: "true", else: "false")}
+            disabled={not @recording_control_available?}
+            aria-label={recording_control_label(@recording_paused?, @recording_control_available?)}
+            data-tooltip={recording_control_label(@recording_paused?, @recording_control_available?)}
           >
             <svg
-              :if={@recorder_activity == :recording}
+              :if={not @recording_paused?}
               viewBox="0 0 24 24"
               fill="none"
               aria-hidden="true"
@@ -139,7 +140,7 @@ if Code.ensure_loaded?(Phoenix.Component) do
               <rect x="14" y="6" width="3" height="12" rx="1" />
             </svg>
             <svg
-              :if={@recorder_activity != :recording}
+              :if={@recording_paused?}
               viewBox="0 0 24 24"
               fill="none"
               aria-hidden="true"
@@ -211,16 +212,46 @@ if Code.ensure_loaded?(Phoenix.Component) do
       ]
     end
 
-    defp status_announcement(:live) do
+    defp recording_control_label(_paused?, false) do
+      "Recording control unavailable"
+    end
+
+    defp recording_control_label(true, true) do
+      "Resume recording"
+    end
+
+    defp recording_control_label(false, true) do
+      "Pause recording"
+    end
+
+    defp status_announcement(status_state, paused?, available?) do
+      runtime = runtime_status_announcement(status_state)
+      recording = recording_status_announcement(paused?, available?)
+      "#{runtime}. #{recording}"
+    end
+
+    defp runtime_status_announcement(:live) do
       "Runtime sampling is live"
     end
 
-    defp status_announcement(:loading) do
+    defp runtime_status_announcement(:loading) do
       "Runtime sampling is starting"
     end
 
-    defp status_announcement(:stale) do
+    defp runtime_status_announcement(:stale) do
       "Runtime sampling is stale"
+    end
+
+    defp recording_status_announcement(_paused?, false) do
+      "Lifecycle recording control is unavailable"
+    end
+
+    defp recording_status_announcement(true, true) do
+      "Lifecycle recording is paused"
+    end
+
+    defp recording_status_announcement(false, true) do
+      "Lifecycle recording is active"
     end
   end
 end

--- a/lib/beam_console_web/console/recording_control_client.ex
+++ b/lib/beam_console_web/console/recording_control_client.ex
@@ -1,0 +1,47 @@
+defmodule BeamConsoleWeb.Console.RecordingControlClient do
+  @moduledoc "Provides an outage-safe boundary around operator recording control."
+
+  alias BeamConsole.Recording
+  alias BeamConsole.Recording.Control
+  alias BeamConsole.Recording.Status
+
+  @default_timeout 250
+
+  @type server :: GenServer.server() | nil
+  @type call_error :: {:error, :timeout | :unavailable}
+
+  @doc "Returns authoritative recording control state when available."
+  @spec status(server(), timeout()) :: {:ok, Status.t()} | call_error()
+  def status(server \\ Control, timeout \\ @default_timeout) do
+    safe_call(server, &Recording.status(&1, timeout))
+  end
+
+  @doc "Subscribes the caller to authoritative recording-state transitions."
+  @spec subscribe(server(), timeout()) :: {:ok, Status.t()} | call_error()
+  def subscribe(server \\ Control, timeout \\ @default_timeout) do
+    safe_call(server, &Control.subscribe(&1, timeout))
+  end
+
+  @doc "Pauses recording through the authoritative control process."
+  @spec pause(server(), timeout()) :: {:ok, Status.t()} | call_error()
+  def pause(server \\ Control, timeout \\ @default_timeout) do
+    safe_call(server, &Recording.pause(&1, timeout))
+  end
+
+  @doc "Resumes recording through the authoritative control process."
+  @spec resume(server(), timeout()) :: {:ok, Status.t()} | call_error()
+  def resume(server \\ Control, timeout \\ @default_timeout) do
+    safe_call(server, &Recording.resume(&1, timeout))
+  end
+
+  defp safe_call(server, operation) when not is_nil(server) and is_function(operation, 1) do
+    {:ok, operation.(server)}
+  catch
+    :exit, {:timeout, _details} -> {:error, :timeout}
+    :exit, _reason -> {:error, :unavailable}
+  end
+
+  defp safe_call(_server, _operation) do
+    {:error, :unavailable}
+  end
+end

--- a/lib/beam_console_web/console_live.ex
+++ b/lib/beam_console_web/console_live.ex
@@ -19,6 +19,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     alias BeamConsole.ApplicationTreeConfig
     alias BeamConsole.Recorder.Status, as: RecorderStatus
+    alias BeamConsole.Recording.Control, as: RecordingControl
+    alias BeamConsole.Recording.Status, as: RecordingStatus
     alias BeamConsole.Snapshot
     alias BeamConsoleWeb.Console.ActivityPresenter
     alias BeamConsoleWeb.Console.ApplicationTreePresenter
@@ -29,6 +31,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     alias BeamConsoleWeb.Console.Params
     alias BeamConsoleWeb.Console.Paths
     alias BeamConsoleWeb.Console.RecorderClient
+    alias BeamConsoleWeb.Console.RecordingControlClient
     alias BeamConsoleWeb.Console.RuntimePresenter
     alias BeamConsoleWeb.Console.SelectionState
     alias BeamConsoleWeb.Graph
@@ -62,6 +65,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         |> assign(:collector_retry_timer, nil)
         |> assign(:collector_retry_token, nil)
         |> assign(:recorder_status, %RecorderStatus{})
+        |> assign(:recording_status, %RecordingStatus{paused?: false, revision: 0})
+        |> assign(:recording_control_available?, false)
         |> assign(:recorder_label, "Inactive")
         |> assign(:process_count, 0)
         |> assign(:process_matching_count, 0)
@@ -160,27 +165,44 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     def handle_event("toggle_recording", _params, socket) do
       result =
-        case socket.assigns.recorder_status.activity do
-          :recording -> RecorderClient.pause()
-          _other -> RecorderClient.resume()
+        case socket.assigns.recording_status.paused? do
+          true -> RecordingControlClient.resume()
+          false -> RecordingControlClient.pause()
         end
 
       case result do
         {:ok, status} ->
           socket =
             socket
-            |> assign_recorder_status(status)
+            |> assign(:recording_status, status)
+            |> assign(:recording_control_available?, true)
+            |> assign_current_recorder_status()
             |> load_lifecycle()
             |> load_stats()
 
           {:noreply, socket}
 
         {:error, reason} when reason in [:timeout, :unavailable] ->
-          {:noreply, assign_recorder_unavailable(socket)}
+          {:noreply, assign(socket, :recording_control_available?, false)}
       end
     end
 
     @impl Phoenix.LiveView
+    def handle_info(
+          {RecordingControl, %RecordingStatus{} = status},
+          socket
+        ) do
+      socket =
+        socket
+        |> assign(:recording_status, status)
+        |> assign(:recording_control_available?, true)
+        |> assign_current_recorder_status()
+        |> load_lifecycle()
+        |> load_stats()
+
+      {:noreply, socket}
+    end
+
     def handle_info({:beam_console_snapshot, sequence}, socket) do
       case CollectorClient.latest_snapshot(socket.assigns.collector_pid) do
         {:ok, snapshot} ->
@@ -241,7 +263,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             filter_form={@filter_form}
             tab={@tab}
             tab_paths={@tab_paths}
-            recorder_activity={@recorder_status.activity}
+            recording_paused?={@recording_status.paused?}
+            recording_control_available?={@recording_control_available?}
             refresh_pending?={@graph_refresh_pending?}
           />
 
@@ -314,6 +337,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     defp subscribe_collector(socket) do
+      socket = subscribe_recording_control(socket)
+
       case Process.whereis(BeamConsole.Collector) do
         collector when is_pid(collector) ->
           subscribe_to_collector(socket, collector)
@@ -466,7 +491,32 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       socket
       |> assign(:status_label, status_label)
       |> assign(:status_state, status_state)
+      |> assign_current_recording_status()
       |> assign_current_recorder_status()
+    end
+
+    defp assign_current_recording_status(socket) do
+      case RecordingControlClient.status() do
+        {:ok, status} ->
+          socket
+          |> assign(:recording_status, status)
+          |> assign(:recording_control_available?, true)
+
+        {:error, reason} when reason in [:timeout, :unavailable] ->
+          assign(socket, :recording_control_available?, false)
+      end
+    end
+
+    defp subscribe_recording_control(socket) do
+      case RecordingControlClient.subscribe() do
+        {:ok, status} ->
+          socket
+          |> assign(:recording_status, status)
+          |> assign(:recording_control_available?, true)
+
+        {:error, reason} when reason in [:timeout, :unavailable] ->
+          assign(socket, :recording_control_available?, false)
+      end
     end
 
     defp assign_current_recorder_status(socket) do
@@ -480,6 +530,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     defp assign_recorder_status(socket, recorder_status) do
+      recorder_status = reflect_control_pause(recorder_status, socket.assigns.recording_status)
+
       socket
       |> assign(:recorder_status, recorder_status)
       |> assign(:recorder_label, LifecyclePresenter.activity_label(recorder_status))
@@ -489,6 +541,21 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       socket
       |> assign(:recorder_status, %RecorderStatus{})
       |> assign(:recorder_label, "Unavailable")
+    end
+
+    defp reflect_control_pause(recorder_status, %RecordingStatus{paused?: true}) do
+      %{
+        recorder_status
+        | activity: :paused,
+          active?: false,
+          paused?: true,
+          watched: 0,
+          pending_correlations: 0
+      }
+    end
+
+    defp reflect_control_pause(recorder_status, %RecordingStatus{paused?: false}) do
+      recorder_status
     end
 
     defp load_lifecycle(socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BeamConsole.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ccarvalho-eng/beam_console"
-  @version "0.3.0"
+  @version "0.4.0"
 
   def project do
     [

--- a/test/beam_console/collector_test.exs
+++ b/test/beam_console/collector_test.exs
@@ -6,6 +6,7 @@ defmodule BeamConsole.CollectorTest do
   alias BeamConsole.Lifecycle.Observation
   alias BeamConsole.Lifecycle.Recorder, as: LifecycleRecorder
   alias BeamConsole.Recorder.Config, as: RecorderConfig
+  alias BeamConsole.Recording.Control, as: RecordingControl
   alias BeamConsole.Snapshot
 
   defmodule FakeRuntime do
@@ -243,7 +244,7 @@ defmodule BeamConsole.CollectorTest do
       )
 
     assert {:ok, nil} = Collector.subscribe(collector)
-    assert_receive {:scan_started, 1, scanner}
+    assert_receive {:scan_started, 1, scanner}, 1_000
     send(scanner, :release)
 
     assert_receive {:"$gen_cast", {:observe, frame, [], _options}}
@@ -370,6 +371,174 @@ defmodule BeamConsole.CollectorTest do
     send(replacement_scanner, :release)
     assert_receive {:"$gen_cast", :activate}
     assert_receive {:"$gen_cast", {:observe, _frame, [], _options}}
+  end
+
+  test "a paused always-on collector settles one in-flight scan and stops without viewers" do
+    control = start_recording_control()
+    name = Module.concat(__MODULE__, "PausedAlwaysCollector#{System.unique_integer([:positive])}")
+
+    collector =
+      start_supervised!(
+        Supervisor.child_spec(
+          {Collector,
+           name: name,
+           runtime: FakeRuntime,
+           runtime_options: [owner: self()],
+           lifecycle_recorder: self(),
+           recording_control: control,
+           always_record?: true,
+           interval: 20,
+           scan_timeout: 2_000,
+           task_supervisor: BeamConsole.TaskSupervisor},
+          id: name
+        )
+      )
+
+    assert_receive {:scan_started, 1, scanner}
+    RecordingControl.pause(control)
+    assert eventually(fn -> :sys.get_state(collector).recording_paused? end)
+
+    send(scanner, :release)
+    refute_receive {:scan_started, 2, _scanner}, 100
+
+    assert :ok = Collector.request_reconciliation(collector)
+    refute_receive {:scan_started, 2, _scanner}, 100
+
+    assert :ok = Collector.request_refresh(collector)
+    assert_receive {:scan_started, 2, manual_scanner}
+    send(manual_scanner, :release)
+    refute_receive {:scan_started, 3, _scanner}, 100
+
+    RecordingControl.resume(control)
+    assert_receive {:scan_started, 3, resumed_scanner}
+    send(resumed_scanner, :release)
+  end
+
+  test "a connected viewer keeps live sampling while recording is paused" do
+    control = start_recording_control()
+    name = Module.concat(__MODULE__, "PausedViewerCollector#{System.unique_integer([:positive])}")
+
+    collector =
+      start_supervised!(
+        Supervisor.child_spec(
+          {Collector,
+           name: name,
+           runtime: FakeRuntime,
+           runtime_options: [owner: self()],
+           lifecycle_recorder: self(),
+           recording_control: control,
+           always_record?: true,
+           interval: 20,
+           scan_timeout: 2_000,
+           task_supervisor: BeamConsole.TaskSupervisor},
+          id: name
+        )
+      )
+
+    assert {:ok, nil} = Collector.subscribe(collector)
+    assert_receive {:scan_started, 1, scanner}
+    RecordingControl.pause(control)
+    assert eventually(fn -> :sys.get_state(collector).recording_paused? end)
+
+    send(scanner, :release)
+    assert_receive {:beam_console_snapshot, 1}
+    assert :ok = Collector.acknowledge(1, collector)
+    assert_receive {:scan_started, 2, next_scanner}
+    send(next_scanner, :release)
+    assert_receive {:beam_console_snapshot, 2}
+    assert :ok = Collector.unsubscribe(collector)
+    refute_receive {:scan_started, 3, _scanner}, 100
+  end
+
+  test "a failed in-flight scan cannot revive paused zero-viewer sampling" do
+    control = start_recording_control()
+
+    name =
+      Module.concat(__MODULE__, "PausedFailureCollector#{System.unique_integer([:positive])}")
+
+    collector =
+      start_supervised!(
+        Supervisor.child_spec(
+          {Collector,
+           name: name,
+           runtime: FakeRuntime,
+           runtime_options: [owner: self()],
+           recording_control: control,
+           always_record?: true,
+           interval: 20,
+           scan_timeout: 2_000,
+           task_supervisor: BeamConsole.TaskSupervisor},
+          id: name
+        )
+      )
+
+    assert_receive {:scan_started, 1, scanner}
+    RecordingControl.pause(control)
+    assert eventually(fn -> :sys.get_state(collector).recording_paused? end)
+    send(scanner, {:release, {:error, :fixture_failure}})
+
+    assert eventually_after(fn -> not Collector.status(collector).scanning? end)
+    refute_receive {:scan_started, 2, _scanner}, 100
+  end
+
+  test "a timed-out in-flight scan cannot revive paused zero-viewer sampling" do
+    control = start_recording_control()
+
+    name =
+      Module.concat(__MODULE__, "PausedTimeoutCollector#{System.unique_integer([:positive])}")
+
+    collector =
+      start_supervised!(
+        Supervisor.child_spec(
+          {Collector,
+           name: name,
+           runtime: FakeRuntime,
+           runtime_options: [owner: self()],
+           recording_control: control,
+           always_record?: true,
+           interval: 20,
+           scan_timeout: 20,
+           task_supervisor: BeamConsole.TaskSupervisor},
+          id: name
+        )
+      )
+
+    assert_receive {:scan_started, 1, _scanner}
+    RecordingControl.pause(control)
+    assert eventually(fn -> :sys.get_state(collector).recording_paused? end)
+
+    assert eventually_after(fn -> not Collector.status(collector).scanning? end)
+    refute_receive {:scan_started, 2, _scanner}, 100
+  end
+
+  test "a paused control prevents restarted always-on collectors from sampling" do
+    control = start_recording_control()
+    RecordingControl.pause(control)
+
+    name =
+      Module.concat(__MODULE__, "RestartPausedCollector#{System.unique_integer([:positive])}")
+
+    collector_spec =
+      Supervisor.child_spec(
+        {Collector,
+         name: name,
+         runtime: FakeRuntime,
+         runtime_options: [owner: self()],
+         lifecycle_recorder: self(),
+         recording_control: control,
+         always_record?: true,
+         interval: 20,
+         scan_timeout: 2_000,
+         task_supervisor: BeamConsole.TaskSupervisor},
+        id: name
+      )
+
+    _collector = start_supervised!(collector_spec)
+    refute_receive {:scan_started, 1, _scanner}, 100
+
+    assert :ok = stop_supervised(name)
+    _replacement = start_supervised!(collector_spec)
+    refute_receive {:scan_started, 1, _scanner}, 100
   end
 
   test "reactivates a restarted recorder while a viewer remains subscribed" do
@@ -664,7 +833,7 @@ defmodule BeamConsole.CollectorTest do
         Collector.refresh(collector)
       end
 
-      assert_receive {:probe_scan_started, 1}
+      assert_receive {:probe_scan_started, 1}, 1_000
 
       if attempt == 1 do
         assert_receive :blocking_supervisor_called
@@ -726,6 +895,12 @@ defmodule BeamConsole.CollectorTest do
     end
   end
 
+  defp start_recording_control do
+    name = Module.concat(__MODULE__, "RecordingControl#{System.unique_integer([:positive])}")
+
+    start_supervised!(Supervisor.child_spec({RecordingControl, name: name}, id: name))
+  end
+
   defp controlled_subscriber_loop(collector, owner) do
     receive do
       {:beam_console_snapshot, sequence} ->
@@ -753,6 +928,21 @@ defmodule BeamConsole.CollectorTest do
   end
 
   defp eventually(_fun, 0) do
+    false
+  end
+
+  defp eventually_after(fun, attempts \\ 100)
+
+  defp eventually_after(fun, attempts) when attempts > 0 do
+    if fun.() do
+      true
+    else
+      Process.sleep(1)
+      eventually_after(fun, attempts - 1)
+    end
+  end
+
+  defp eventually_after(_fun, 0) do
     false
   end
 end

--- a/test/beam_console/lifecycle/recorder_test.exs
+++ b/test/beam_console/lifecycle/recorder_test.exs
@@ -5,6 +5,7 @@ defmodule BeamConsole.Lifecycle.RecorderTest do
   alias BeamConsole.Lifecycle.Recorder
   alias BeamConsole.Recorder.Config
   alias BeamConsole.Recorder.Frame
+  alias BeamConsole.Recording.Control, as: RecordingControl
 
   test "records sanitized direct exits only after lazy activation" do
     recorder = start_recorder()
@@ -116,6 +117,31 @@ defmodule BeamConsole.Lifecycle.RecorderTest do
     assert Recorder.resume(recorder).activity == :recording
   end
 
+  test "always mode starts paused and stays paused across recorder restarts" do
+    control = start_recording_control()
+    RecordingControl.pause(control)
+    name = Module.concat(__MODULE__, "ControlledRecorder#{System.unique_integer([:positive])}")
+
+    recorder_spec =
+      Supervisor.child_spec(
+        {Recorder,
+         name: name,
+         config: Config.new!(mode: :always),
+         recording_control: control,
+         refresh_requester: nil},
+        id: name
+      )
+
+    recorder = start_supervised!(recorder_spec)
+    assert eventually(fn -> Recorder.status(recorder).paused? end)
+    refute Recorder.status(recorder).active?
+
+    assert :ok = stop_supervised(name)
+    replacement = start_supervised!(recorder_spec)
+    assert eventually(fn -> Recorder.status(replacement).paused? end)
+    refute Recorder.status(replacement).active?
+  end
+
   test "resume requests a deferred reconciliation when recording demand remains" do
     owner = self()
     requester = fn -> send(owner, :refresh_requested) end
@@ -155,6 +181,76 @@ defmodule BeamConsole.Lifecycle.RecorderTest do
 
     send(requester_pid, :release_refresh)
     assert eventually(fn -> Recorder.status(recorder).missed_reconciliations == 0 end)
+  end
+
+  test "authoritative pause cancels an in-flight reconciliation and suppresses stale work" do
+    owner = self()
+
+    requester = fn ->
+      send(owner, {:controlled_refresh_started, self()})
+      Process.sleep(:infinity)
+    end
+
+    control = start_recording_control()
+
+    recorder =
+      start_recorder(
+        [mode: :always],
+        recording_control: control,
+        refresh_requester: requester,
+        refresh_timeout: 1_000
+      )
+
+    send(recorder, :reconcile_after_down)
+    assert_receive {:controlled_refresh_started, first_requester}
+    first_monitor = Process.monitor(first_requester)
+
+    RecordingControl.pause(control)
+    assert eventually(fn -> Recorder.status(recorder).paused? end)
+    assert_receive {:DOWN, ^first_monitor, :process, ^first_requester, _reason}
+
+    send(recorder, :reconcile_after_down)
+    refute_receive {:controlled_refresh_started, _requester}, 100
+
+    RecordingControl.resume(control)
+    assert_receive {:controlled_refresh_started, resumed_requester}
+    Process.exit(resumed_requester, :kill)
+  end
+
+  test "resume waits for a canceling reconciliation to terminate before starting another" do
+    owner = self()
+
+    requester = fn ->
+      send(owner, {:controlled_refresh_started, self()})
+      Process.sleep(:infinity)
+    end
+
+    control = start_recording_control()
+
+    recorder =
+      start_recorder(
+        [mode: :always],
+        recording_control: control,
+        refresh_requester: requester,
+        refresh_timeout: 1_000
+      )
+
+    send(recorder, :reconcile_after_down)
+    assert_receive {:controlled_refresh_started, first_requester}
+
+    guardian = :sys.get_state(recorder).refresh_request.pid
+    true = :erlang.suspend_process(guardian)
+
+    RecordingControl.pause(control)
+    RecordingControl.resume(control)
+
+    refute_receive {:controlled_refresh_started, _requester}, 100
+    assert Process.alive?(first_requester)
+
+    true = :erlang.resume_process(guardian)
+    assert_receive {:controlled_refresh_started, second_requester}
+    refute second_requester == first_requester
+    Process.exit(second_requester, :kill)
   end
 
   test "requester failures are sanitized and counted without stopping recording" do
@@ -541,6 +637,12 @@ defmodule BeamConsole.Lifecycle.RecorderTest do
     end)
 
     pid
+  end
+
+  defp start_recording_control do
+    name = Module.concat(__MODULE__, "RecordingControl#{System.unique_integer([:positive])}")
+
+    start_supervised!(Supervisor.child_spec({RecordingControl, name: name}, id: name))
   end
 
   defp frame(sequence, monotonic_ms, coverage \\ :complete) do

--- a/test/beam_console/recorder_test.exs
+++ b/test/beam_console/recorder_test.exs
@@ -4,6 +4,7 @@ defmodule BeamConsole.RecorderTest do
   alias BeamConsole.Lifecycle.Recorder, as: LifecycleRecorder
   alias BeamConsole.Recorder
   alias BeamConsole.Recorder.Config
+  alias BeamConsole.Recording.Control
 
   test "public facade exposes recording status and controls" do
     name = Module.concat(__MODULE__, "Recorder#{System.unique_integer([:positive])}")
@@ -22,6 +23,27 @@ defmodule BeamConsole.RecorderTest do
     assert Recorder.pause(recorder).activity == :paused
     assert Recorder.resume(recorder).activity == :recording
     assert Recorder.events([], recorder).items == []
+  end
+
+  test "public recorder controls update the configured authority" do
+    control = start_supervised!({Control, name: nil})
+
+    recorder =
+      start_supervised!(
+        Supervisor.child_spec(
+          {LifecycleRecorder,
+           name: nil,
+           config: Config.new!(mode: :always),
+           collector: nil,
+           recording_control: control},
+          id: System.unique_integer([:positive])
+        )
+      )
+
+    assert Recorder.pause(recorder).activity == :paused
+    assert Control.status(control).paused?
+    assert Recorder.resume(recorder).activity == :recording
+    refute Control.status(control).paused?
   end
 
   test "rejects malformed query options without terminating the recorder" do

--- a/test/beam_console/recording/control_test.exs
+++ b/test/beam_console/recording/control_test.exs
@@ -1,0 +1,79 @@
+defmodule BeamConsole.Recording.ControlTest do
+  use ExUnit.Case, async: true
+
+  alias BeamConsole.Recording
+  alias BeamConsole.Recording.Control
+  alias BeamConsole.Recording.Status
+
+  test "stores an idempotent operator pause and broadcasts revisions to registered consumers" do
+    control = start_control()
+
+    assert %Status{paused?: false, revision: 0} = Control.register(:collector, control)
+    assert %Status{paused?: true, revision: 1} = Control.pause(control)
+    assert_receive {Control, %Status{paused?: true, revision: 1}}
+
+    assert %Status{paused?: true, revision: 1} = Control.pause(control)
+    refute_receive {Control, %Status{revision: 2}}
+
+    assert %Status{paused?: false, revision: 2} = Control.resume(control)
+    assert_receive {Control, %Status{paused?: false, revision: 2}}
+  end
+
+  test "a replacement consumer receives the current authoritative state" do
+    control = start_control()
+    owner = self()
+
+    first = register_consumer(control, owner)
+    assert_receive {:registered, ^first, %Status{paused?: false}}
+
+    assert %Status{paused?: true} = Control.pause(control)
+    assert_receive {:control_status, ^first, %Status{paused?: true}}
+
+    Process.exit(first, :kill)
+
+    replacement = register_consumer(control, owner)
+    assert_receive {:registered, ^replacement, %Status{paused?: true}}
+  end
+
+  test "subscribers receive transitions without occupying a runtime-service role" do
+    control = start_control()
+
+    assert %Status{paused?: false} = Control.subscribe(control)
+    assert %Status{paused?: true, revision: 1} = Control.pause(control)
+    assert_receive {Control, %Status{paused?: true, revision: 1}}
+  end
+
+  test "the public facade delegates bounded control transitions" do
+    control = start_control()
+
+    assert %Status{paused?: true} = Recording.pause(control, 100)
+    assert %Status{paused?: true} = Recording.status(control, 100)
+    assert %Status{paused?: false} = Recording.resume(control, 100)
+  end
+
+  defp start_control do
+    name = Module.concat(__MODULE__, "Control#{System.unique_integer([:positive])}")
+
+    start_supervised!(Supervisor.child_spec({Control, name: name}, id: name))
+  end
+
+  defp register_consumer(control, owner) do
+    spawn(fn ->
+      control_monitor = Process.monitor(control)
+      status = Control.register(:collector, control)
+      send(owner, {:registered, self(), status})
+      relay_control_status(owner, control_monitor)
+    end)
+  end
+
+  defp relay_control_status(owner, control_monitor) do
+    receive do
+      {Control, %Status{} = status} ->
+        send(owner, {:control_status, self(), status})
+        relay_control_status(owner, control_monitor)
+
+      {:DOWN, ^control_monitor, :process, _control, _reason} ->
+        :ok
+    end
+  end
+end

--- a/test/beam_console/recording/restart_test.exs
+++ b/test/beam_console/recording/restart_test.exs
@@ -1,0 +1,94 @@
+defmodule BeamConsole.Recording.RestartTest do
+  use ExUnit.Case, async: false
+
+  alias BeamConsole.Recording
+  alias BeamConsole.Recording.Control
+
+  setup do
+    Recording.resume()
+    on_exit(&Recording.resume/0)
+    :ok
+  end
+
+  test "a control crash restarts and reconnects both runtime consumers" do
+    old_control = Process.whereis(Control)
+    old_recorder = Process.whereis(BeamConsole.Lifecycle.Recorder)
+    old_collector = Process.whereis(BeamConsole.Collector)
+
+    references =
+      Enum.map([old_control, old_recorder, old_collector], fn process ->
+        {process, Process.monitor(process)}
+      end)
+
+    Process.exit(old_control, :kill)
+
+    Enum.each(references, fn {process, reference} ->
+      assert_receive {:DOWN, ^reference, :process, ^process, _reason}, 2_000
+    end)
+
+    assert eventually(fn -> replacement?(Control, old_control) end)
+    assert eventually(fn -> replacement?(BeamConsole.Lifecycle.Recorder, old_recorder) end)
+    assert eventually(fn -> replacement?(BeamConsole.Collector, old_collector) end)
+
+    Recording.pause()
+
+    assert eventually(fn ->
+             BeamConsole.Recorder.status().paused? and
+               :sys.get_state(BeamConsole.Collector).recording_paused?
+           end)
+
+    Recording.resume()
+
+    assert eventually(fn ->
+             not BeamConsole.Recorder.status().paused? and
+               not :sys.get_state(BeamConsole.Collector).recording_paused?
+           end)
+  end
+
+  test "a task-supervisor crash preserves authoritative pause intent" do
+    Recording.pause()
+
+    control = Process.whereis(Control)
+    old_task_supervisor = Process.whereis(BeamConsole.TaskSupervisor)
+    old_recorder = Process.whereis(BeamConsole.Lifecycle.Recorder)
+    old_collector = Process.whereis(BeamConsole.Collector)
+    reference = Process.monitor(old_task_supervisor)
+
+    Process.exit(old_task_supervisor, :kill)
+    assert_receive {:DOWN, ^reference, :process, ^old_task_supervisor, _reason}, 2_000
+
+    assert Process.whereis(Control) == control
+    assert eventually(fn -> replacement?(BeamConsole.TaskSupervisor, old_task_supervisor) end)
+    assert eventually(fn -> replacement?(BeamConsole.Lifecycle.Recorder, old_recorder) end)
+    assert eventually(fn -> replacement?(BeamConsole.Collector, old_collector) end)
+
+    assert Recording.status().paused?
+
+    assert eventually(fn ->
+             BeamConsole.Recorder.status().paused? and
+               :sys.get_state(BeamConsole.Collector).recording_paused?
+           end)
+  end
+
+  defp replacement?(name, previous) do
+    case Process.whereis(name) do
+      process when is_pid(process) -> process != previous and Process.alive?(process)
+      nil -> false
+    end
+  end
+
+  defp eventually(function, attempts \\ 80)
+
+  defp eventually(function, 0) do
+    function.()
+  end
+
+  defp eventually(function, attempts) do
+    if function.() do
+      true
+    else
+      Process.sleep(25)
+      eventually(function, attempts - 1)
+    end
+  end
+end

--- a/test/beam_console_web/console/runtime_clients_test.exs
+++ b/test/beam_console_web/console/runtime_clients_test.exs
@@ -3,6 +3,7 @@ defmodule BeamConsoleWeb.Console.RuntimeClientsTest do
 
   alias BeamConsoleWeb.Console.CollectorClient
   alias BeamConsoleWeb.Console.RecorderClient
+  alias BeamConsoleWeb.Console.RecordingControlClient
 
   defmodule WedgedServer do
     use GenServer
@@ -38,6 +39,15 @@ defmodule BeamConsoleWeb.Console.RuntimeClientsTest do
     assert System.monotonic_time(:millisecond) - started_at < 250
   end
 
+  test "recording control calls return a typed timeout without imposing the default call wait" do
+    server = start_supervised!(WedgedServer)
+    started_at = System.monotonic_time(:millisecond)
+
+    assert {:error, :timeout} = RecordingControlClient.status(server, 20)
+    assert {:error, :timeout} = RecordingControlClient.subscribe(server, 20)
+    assert System.monotonic_time(:millisecond) - started_at < 250
+  end
+
   test "dead runtime services remain distinguishable from timeouts" do
     server = start_supervised!(WedgedServer)
     reference = Process.monitor(server)
@@ -46,5 +56,7 @@ defmodule BeamConsoleWeb.Console.RuntimeClientsTest do
 
     assert {:error, :unavailable} = CollectorClient.status(server, 20)
     assert {:error, :unavailable} = RecorderClient.status(server, 20)
+    assert {:error, :unavailable} = RecordingControlClient.status(server, 20)
+    assert {:error, :unavailable} = RecordingControlClient.subscribe(server, 20)
   end
 end

--- a/test/beam_console_web/console_live_test.exs
+++ b/test/beam_console_web/console_live_test.exs
@@ -8,6 +8,7 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
 
   setup do
     start_supervised!(@endpoint)
+    BeamConsole.Recording.resume()
 
     {:ok, snapshot} = BeamConsole.subscribe()
 
@@ -21,7 +22,10 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
         BeamConsole.latest_snapshot()
       end
 
-    on_exit(&BeamConsole.unsubscribe/0)
+    on_exit(fn ->
+      BeamConsole.Recording.resume()
+      BeamConsole.unsubscribe()
+    end)
 
     %{snapshot: snapshot}
   end
@@ -164,6 +168,26 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
 
     render_click(view, "toggle_recording", %{})
     assert has_element?(view, "#beam-console-recorder-control[aria-label='Pause recording']")
+  end
+
+  test "shares authoritative recording control across connected views" do
+    {:ok, first, _html} = live(build_conn(), "/beam/lifecycle")
+    {:ok, second, _html} = live(build_conn(), "/beam/runtime")
+
+    render_click(first, "toggle_recording", %{})
+
+    assert eventually(fn ->
+             has_element?(
+               second,
+               "#beam-console-recorder-control[aria-label='Resume recording']"
+             )
+           end)
+
+    render_click(second, "toggle_recording", %{})
+
+    assert eventually(fn ->
+             has_element?(first, "#beam-console-recorder-control[aria-label='Pause recording']")
+           end)
   end
 
   test "does not retain full runtime snapshots in LiveView assigns" do


### PR DESCRIPTION
## Summary

- add one authoritative pause state shared by runtime sampling and lifecycle recording
- stop zero-viewer background work while paused without freezing connected dashboards
- synchronize controls across LiveView sessions and preserve intent across dependent process restarts
- serialize reconciliation cancellation and resume so refresh callbacks remain single-flight
- prepare the 0.4.0 release documentation and package metadata

## Runtime flow

```mermaid
flowchart LR
  UI[Console or public API] --> Control[Recording Control]
  Control --> Recorder[Lifecycle Recorder]
  Control --> Collector[Runtime Collector]
  Recorder -->|bounded reconciliation| Collector
  Collector -->|bounded observations| Recorder
```

## Safety

The feature remains read-only. Pausing removes lifecycle watches and zero-viewer background demand; manual refresh stays bounded, connected viewers remain live, and retained history remains bounded.