### PR TITLE
feat(inspector): add safe process diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add bounded scheduling, heap, and garbage-collection diagnostics to the process inspector.
+- Make process group leaders selectable when they are present in the latest snapshot.
+
 ## 0.4.0 - 2026-08-27
 
 - Add restart-safe operator recording control shared by the collector and lifecycle recorder.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Call `BeamConsole.unsubscribe/0` when a long-lived manual subscriber no longer n
 - Lifecycle: observed process starts, terminations, and replacement correlations with explicit evidence and coverage language.
 - Activity: reductions per second, mailbox growth, memory movement, and ranked process movers.
 - Runtime: BEAM memory categories, run queue, atom count and utilization, runtime inventory, collector duration, applications, ETS tables, and connected-node inventory.
-- Inspector: allowlisted process, application, and node details. Process relationships are clickable when their target is present in the latest sample.
+- Inspector: allowlisted process, application, and node details, including scheduling, heap, and selected garbage-collection diagnostics. Process relationships and group leaders are clickable when their target is present in the latest sample.
 
 Applications are grouped into host, dependencies, OTP, and tooling categories. Every tree branch can be collapsed and its state remains stable while LiveView updates.
 

--- a/assets/css/lifecycle.css
+++ b/assets/css/lifecycle.css
@@ -242,11 +242,13 @@
   text-align: right;
 }
 
-.beam-console-relation {
+.beam-console-relation,
+.beam-console-diagnostics {
   margin-top: 17px;
 }
 
-.beam-console-relation h4 {
+.beam-console-relation h4,
+.beam-console-diagnostics h4 {
   margin: 0 0 7px;
   color: var(--bc-muted);
   font-size: 9px;

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -52,6 +52,10 @@
     grid-column: 2;
     grid-row: 1 / span 2;
   }
+
+  .beam-console-diagnostics {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (max-width: 760px) {

--- a/assets/test/client-contracts.test.mjs
+++ b/assets/test/client-contracts.test.mjs
@@ -331,6 +331,18 @@ test("runtime summary adapts before cards become cramped", async () => {
   );
 });
 
+test("tablet process diagnostics do not compete with relationship rows", async () => {
+  const stylesheet = await readFile(
+    new URL("../../priv/static/beam_console.css", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(
+    stylesheet,
+    /@media \(max-width: 1180px\)[\s\S]*?\.beam-console-diagnostics\s*\{[\s\S]*?grid-column:\s*1 \/ -1/
+  );
+});
+
 test("header navigation keeps a fixed center column across tabs", async () => {
   const stylesheet = await readFile(
     new URL("../../priv/static/beam_console.css", import.meta.url),

--- a/lib/beam_console/process_detail.ex
+++ b/lib/beam_console/process_detail.ex
@@ -7,6 +7,7 @@ defmodule BeamConsole.ProcessDetail do
   """
 
   alias BeamConsole.ProcessRelation
+  alias BeamConsole.ProcessDetail.Diagnostics
 
   @enforce_keys [:id, :pid_text, :label]
   defstruct [
@@ -22,6 +23,7 @@ defmodule BeamConsole.ProcessDetail do
     :message_queue_len,
     :status,
     :last_seen_at,
+    :diagnostics,
     links: [],
     monitors: [],
     monitored_by: [],
@@ -48,6 +50,7 @@ defmodule BeamConsole.ProcessDetail do
           message_queue_len: non_neg_integer() | nil,
           status: atom() | nil,
           last_seen_at: DateTime.t() | nil,
+          diagnostics: Diagnostics.t() | nil,
           links: [ProcessRelation.t()],
           monitors: [ProcessRelation.t()],
           monitored_by: [ProcessRelation.t()],

--- a/lib/beam_console/process_detail/diagnostics.ex
+++ b/lib/beam_console/process_detail/diagnostics.ex
@@ -1,0 +1,35 @@
+defmodule BeamConsole.ProcessDetail.Diagnostics do
+  @moduledoc """
+  Contains bounded, read-only scheduling and memory diagnostics for a process.
+
+  The struct intentionally excludes mailbox contents, process dictionaries,
+  stacktraces, and arbitrary process state.
+  """
+
+  alias BeamConsole.ProcessRelation
+
+  defstruct [
+    :initial_call,
+    :trap_exit,
+    :priority,
+    :group_leader,
+    :total_heap_size,
+    :heap_size,
+    :stack_size,
+    :minor_gcs,
+    :fullsweep_after
+  ]
+
+  @type priority :: :low | :normal | :high | :max
+  @type t :: %__MODULE__{
+          initial_call: String.t() | nil,
+          trap_exit: boolean() | nil,
+          priority: priority() | nil,
+          group_leader: ProcessRelation.t() | nil,
+          total_heap_size: non_neg_integer() | nil,
+          heap_size: non_neg_integer() | nil,
+          stack_size: non_neg_integer() | nil,
+          minor_gcs: non_neg_integer() | nil,
+          fullsweep_after: non_neg_integer() | nil
+        }
+end

--- a/lib/beam_console/runtime/local.ex
+++ b/lib/beam_console/runtime/local.ex
@@ -14,6 +14,7 @@ defmodule BeamConsole.Runtime.Local do
   alias BeamConsole.EntityId
   alias BeamConsole.NodeInfo
   alias BeamConsole.ProcessDetail
+  alias BeamConsole.ProcessDetail.Diagnostics
   alias BeamConsole.ProcessInfo
   alias BeamConsole.ProcessRelation
   alias BeamConsole.Runtime.Sample, as: RuntimeSample
@@ -30,7 +31,20 @@ defmodule BeamConsole.Runtime.Local do
     :status
   ]
 
-  @detail_fields @process_fields ++ [:current_function, :links, :monitors, :monitored_by]
+  @detail_fields @process_fields ++
+                   [
+                     :current_function,
+                     :links,
+                     :monitors,
+                     :monitored_by,
+                     :trap_exit,
+                     :priority,
+                     :group_leader,
+                     :total_heap_size,
+                     :heap_size,
+                     :stack_size,
+                     :garbage_collection
+                   ]
 
   @impl BeamConsole.Runtime.Adapter
   def snapshot(options) do
@@ -184,6 +198,7 @@ defmodule BeamConsole.Runtime.Local do
            message_queue_len: values[:message_queue_len],
            status: values[:status],
            last_seen_at: context.sampled_at,
+           diagnostics: process_diagnostics(values, context.process_ids),
            links: links,
            monitors: monitors,
            monitored_by: monitored_by,
@@ -209,6 +224,22 @@ defmodule BeamConsole.Runtime.Local do
       sampled_at: snapshot.sampled_at,
       relationship_limit: Config.get(options, :relationship_limit),
       process_ids: snapshot.processes |> Map.keys() |> MapSet.new()
+    }
+  end
+
+  defp process_diagnostics(values, process_ids) do
+    garbage_collection = values[:garbage_collection]
+
+    %Diagnostics{
+      initial_call: function_label(values[:initial_call]),
+      trap_exit: boolean_value(values[:trap_exit]),
+      priority: priority_value(values[:priority]),
+      group_leader: group_leader_relation(values[:group_leader], process_ids),
+      total_heap_size: non_negative_integer(values[:total_heap_size]),
+      heap_size: non_negative_integer(values[:heap_size]),
+      stack_size: non_negative_integer(values[:stack_size]),
+      minor_gcs: garbage_collection_value(garbage_collection, :minor_gcs),
+      fullsweep_after: garbage_collection_value(garbage_collection, :fullsweep_after)
     }
   end
 
@@ -416,6 +447,48 @@ defmodule BeamConsole.Runtime.Local do
   end
 
   defp safe_string(_value) do
+    nil
+  end
+
+  defp boolean_value(value) when is_boolean(value) do
+    value
+  end
+
+  defp boolean_value(_value) do
+    nil
+  end
+
+  defp priority_value(value) when value in [:low, :normal, :high, :max] do
+    value
+  end
+
+  defp priority_value(_value) do
+    nil
+  end
+
+  defp group_leader_relation(pid, process_ids) when is_pid(pid) do
+    process_relation(pid, process_ids)
+  end
+
+  defp group_leader_relation(_group_leader, _process_ids) do
+    nil
+  end
+
+  defp garbage_collection_value(values, key) when is_list(values) do
+    values
+    |> Keyword.get(key)
+    |> non_negative_integer()
+  end
+
+  defp garbage_collection_value(_values, _key) do
+    nil
+  end
+
+  defp non_negative_integer(value) when is_integer(value) and value >= 0 do
+    value
+  end
+
+  defp non_negative_integer(_value) do
     nil
   end
 

--- a/lib/beam_console_web/components/inspector_components.ex
+++ b/lib/beam_console_web/components/inspector_components.ex
@@ -91,6 +91,8 @@ if Code.ensure_loaded?(Phoenix.Component) do
             <dt>Current</dt><dd>{@detail.current_function || "unknown"}</dd>
           </dl>
 
+          <.process_diagnostics diagnostics={@detail.diagnostics} />
+
           <.relation_list
             title="Links"
             values={@detail.links}
@@ -110,6 +112,45 @@ if Code.ensure_loaded?(Phoenix.Component) do
       <% else %>
         <.empty message={@selected.label <> " is no longer available for live inspection."} />
       <% end %>
+      """
+    end
+
+    attr(:diagnostics, :any, default: nil)
+
+    defp process_diagnostics(assigns) do
+      ~H"""
+      <section :if={@diagnostics} class="beam-console-diagnostics">
+        <h4>Scheduling and memory</h4>
+        <dl class="beam-console-fields">
+          <dt>Initial call</dt><dd>{@diagnostics.initial_call || "unknown"}</dd>
+          <dt>Priority</dt><dd>{@diagnostics.priority || "unknown"}</dd>
+          <dt>Trap exits</dt><dd>{format_boolean(@diagnostics.trap_exit)}</dd>
+          <dt>Group leader</dt><dd><.relation_value relation={@diagnostics.group_leader} /></dd>
+          <dt>Heap</dt><dd>{format_words(@diagnostics.heap_size)}</dd>
+          <dt>Total heap</dt><dd>{format_words(@diagnostics.total_heap_size)}</dd>
+          <dt>Stack</dt><dd>{format_words(@diagnostics.stack_size)}</dd>
+          <dt>Minor GCs</dt><dd>{format_integer(@diagnostics.minor_gcs)}</dd>
+          <dt>Fullsweep after</dt><dd>{format_integer(@diagnostics.fullsweep_after)}</dd>
+        </dl>
+      </section>
+      """
+    end
+
+    attr(:relation, :any, default: nil)
+
+    defp relation_value(assigns) do
+      ~H"""
+      <button
+        :if={@relation && @relation.id}
+        type="button"
+        class="beam-console-relation-link"
+        phx-click="select_entity"
+        phx-value-id={@relation.id}
+      >
+        {@relation.label}
+      </button>
+      <span :if={@relation && is_nil(@relation.id)}>{@relation.label}</span>
+      <span :if={is_nil(@relation)}>—</span>
       """
     end
 
@@ -210,8 +251,38 @@ if Code.ensure_loaded?(Phoenix.Component) do
       "—"
     end
 
+    defp format_integer(value) when is_integer(value) and value >= 0 do
+      value
+      |> Integer.to_string()
+      |> String.reverse()
+      |> String.graphemes()
+      |> Enum.chunk_every(3)
+      |> Enum.map_join(",", &Enum.join/1)
+      |> String.reverse()
+    end
+
     defp format_integer(value) do
-      Integer.to_string(value)
+      to_string(value)
+    end
+
+    defp format_words(nil) do
+      "—"
+    end
+
+    defp format_words(value) do
+      "#{format_integer(value)} words"
+    end
+
+    defp format_boolean(true) do
+      "yes"
+    end
+
+    defp format_boolean(false) do
+      "no"
+    end
+
+    defp format_boolean(nil) do
+      "—"
     end
   end
 end

--- a/priv/static/beam_console.css
+++ b/priv/static/beam_console.css
@@ -1139,11 +1139,13 @@
   text-align: right;
 }
 
-.beam-console-relation {
+.beam-console-relation,
+.beam-console-diagnostics {
   margin-top: 17px;
 }
 
-.beam-console-relation h4 {
+.beam-console-relation h4,
+.beam-console-diagnostics h4 {
   margin: 0 0 7px;
   color: var(--bc-muted);
   font-size: 9px;
@@ -1438,6 +1440,10 @@
   .beam-console-fields {
     grid-column: 2;
     grid-row: 1 / span 2;
+  }
+
+  .beam-console-diagnostics {
+    grid-column: 1 / -1;
   }
 }
 

--- a/test/beam_console/runtime/local_test.exs
+++ b/test/beam_console/runtime/local_test.exs
@@ -112,6 +112,44 @@ defmodule BeamConsole.Runtime.LocalTest do
            end)
   end
 
+  test "returns bounded scheduling and memory diagnostics" do
+    owner = self()
+
+    target =
+      spawn(fn ->
+        Process.flag(:trap_exit, true)
+        Process.flag(:priority, :high)
+        send(owner, {:diagnostics_ready, self()})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive {:diagnostics_ready, ^target}
+    on_exit(fn -> send(target, :stop) end)
+
+    assert {:ok, snapshot} = Local.snapshot(sequence: 1, process_limit: 10_000)
+    assert {:ok, detail} = Local.detail(target, snapshot)
+
+    diagnostics = detail.diagnostics
+
+    assert is_binary(diagnostics.initial_call)
+    assert diagnostics.trap_exit
+    assert diagnostics.priority == :high
+    assert diagnostics.group_leader.label == BeamConsole.EntityId.label(Process.group_leader())
+    assert is_integer(diagnostics.heap_size)
+    assert is_integer(diagnostics.total_heap_size)
+    assert diagnostics.total_heap_size >= diagnostics.heap_size
+    assert is_integer(diagnostics.stack_size)
+    assert is_integer(diagnostics.minor_gcs)
+    assert is_integer(diagnostics.fullsweep_after)
+
+    refute Map.has_key?(diagnostics, :dictionary)
+    refute Map.has_key?(diagnostics, :messages)
+    refute Map.has_key?(diagnostics, :stacktrace)
+  end
+
   defp relation_process do
     spawn(fn -> relation_loop() end)
   end

--- a/test/beam_console_web/components/inspector_components_test.exs
+++ b/test/beam_console_web/components/inspector_components_test.exs
@@ -5,6 +5,7 @@ if Code.ensure_loaded?(Phoenix.LiveViewTest) do
     import Phoenix.LiveViewTest
 
     alias BeamConsole.ProcessDetail
+    alias BeamConsole.ProcessDetail.Diagnostics
     alias BeamConsole.ProcessRelation
     alias BeamConsoleWeb.Components.InspectorComponents
 
@@ -47,6 +48,42 @@ if Code.ensure_loaded?(Phoenix.LiveViewTest) do
       assert html =~ ~s(phx-value-id="process-2")
       assert html =~ ~r/<span>\s*Unavailable\s*<\/span>/
       refute html =~ ~s(phx-value-id="Unavailable")
+    end
+
+    test "renders safe scheduling and memory diagnostics" do
+      detail = %ProcessDetail{
+        id: "process-1",
+        pid_text: "<0.1.0>",
+        label: "Worker",
+        diagnostics: %Diagnostics{
+          initial_call: "Elixir.Example.Worker.init/1",
+          trap_exit: true,
+          priority: :normal,
+          group_leader: %ProcessRelation{
+            id: "process-2",
+            label: "<0.2.0>",
+            kind: :process
+          },
+          heap_size: 610,
+          total_heap_size: 987,
+          stack_size: 12,
+          minor_gcs: 4,
+          fullsweep_after: 65_535
+        }
+      }
+
+      html =
+        render_component(&InspectorComponents.inspector/1,
+          selected: %{id: detail.id, kind: :process, label: detail.label},
+          detail: detail
+        )
+
+      assert html =~ "Scheduling and memory"
+      assert html =~ "Elixir.Example.Worker.init/1"
+      assert html =~ "Trap exits"
+      assert html =~ "987 words"
+      assert html =~ "65,535"
+      assert html =~ ~s(phx-value-id="process-2")
     end
   end
 end


### PR DESCRIPTION
## Summary

- add on-demand initial-call, priority, trap-exit, group-leader, heap, stack, and selected garbage-collection diagnostics
- keep all values in a fixed allowlisted struct and make group leaders selectable only when present in the latest snapshot
- add a compact responsive inspector section with regression coverage

## Safety

Inspection remains local-only, snapshot-gated, read-only, and timeout-bounded. Mailbox contents, process dictionaries, stacktraces, arbitrary state, and raw garbage-collection terms remain excluded.