### PR TITLE
feat(runtime): add low-overhead pressure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+## 0.5.0 - 2026-08-27
+
 - Add bounded scheduling, heap, and garbage-collection diagnostics to the process inspector.
 - Make process group leaders selectable when they are present in the latest snapshot.
+- Add uptime, port and process capacity, scheduler topology, and CPU/I/O run-queue pressure.
+- Add gap-aware input and output throughput charts derived from cumulative runtime counters.
+- Replace ETS table enumeration with the constant-time ERTS table count.
 
 ## 0.4.0 - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add BeamConsole to a Phoenix application:
 ```elixir
 def deps do
   [
-    {:beam_console, "~> 0.4.0"}
+    {:beam_console, "~> 0.5.0"}
   ]
 end
 ```
@@ -67,7 +67,7 @@ Call `BeamConsole.unsubscribe/0` when a long-lived manual subscriber no longer n
 - Process Map: a stable, focused supervision graph with optional process links and monitors, plus a searchable process explorer.
 - Lifecycle: observed process starts, terminations, and replacement correlations with explicit evidence and coverage language.
 - Activity: reductions per second, mailbox growth, memory movement, and ranked process movers.
-- Runtime: BEAM memory categories, run queue, atom count and utilization, runtime inventory, collector duration, applications, ETS tables, and connected-node inventory.
+- Runtime: BEAM memory categories, CPU/I/O run queues, input/output throughput, process, port, and atom capacity, scheduler topology, uptime, runtime inventory, collector duration, applications, ETS tables, and connected-node inventory.
 - Inspector: allowlisted process, application, and node details, including scheduling, heap, and selected garbage-collection diagnostics. Process relationships and group leaders are clickable when their target is present in the latest sample.
 
 Applications are grouped into host, dependencies, OTP, and tooling categories. Every tree branch can be collapsed and its state remains stable while LiveView updates.
@@ -169,9 +169,11 @@ config :beam_console, :recorder,
 
 BeamConsole does not fetch process messages, dictionaries, stacktraces, binaries, or arbitrary process state. It does not use `:sys`, tracing, remote RPC, or process mutation. Browser inputs are matched against fixed allowlists and opaque entity IDs are revalidated against the latest snapshot.
 
+Runtime pressure retains only fixed-shape scalar measurements collected from public ERTS APIs inside the existing non-overlapping collector scan. It does not enable scheduler wall-time measurement, inspect allocators, enumerate ports or sockets, expose host paths or endpoints, or retain raw runtime terms. Cumulative I/O counters are converted into rates only between valid adjacent samples; resets, recording gaps, missing counters, regressions, and invalid elapsed times remain chart discontinuities.
+
 ## Compared with Observer and Phoenix LiveDashboard
 
-Observer is a broad Erlang runtime desktop tool. Phoenix LiveDashboard is a Phoenix-focused operational dashboard built around metrics and framework integrations. BeamConsole is narrower: it is an embeddable, process-first tool focused on supervision topology, observed crash-and-replacement history, process relationships, and bounded activity over time.
+Observer is a broad Erlang runtime desktop tool. Phoenix LiveDashboard is a Phoenix-focused operational dashboard built around metrics and framework integrations. BeamConsole combines selected read-only runtime health signals from those tools with an embeddable, process-first view of supervision topology, observed crash-and-replacement history, process relationships, and bounded activity over time.
 
 ## Demo
 

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -210,6 +210,19 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .beam-console-runtime-summary {
+    display: flex;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: inline proximity;
+  }
+
+  .beam-console-runtime-summary > div {
+    min-width: min(180px, 72vw);
+    flex: 0 0 min(180px, 72vw);
+    scroll-snap-align: start;
+  }
+
   .beam-console-chart-grid {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/assets/js/support.mjs
+++ b/assets/js/support.mjs
@@ -47,19 +47,28 @@ export const writeStoredBranchStates = (storageOwner, key, states) => {
 };
 
 export const chartHeadline = (series, unit, formatter) => {
-  const points = series.flatMap(item => Array.isArray(item.points) ? item.points : []);
-  if (!points.length) return "No data";
-  if (series.length > 1) return `${series.length} series`;
-  return formatter(series[0].points.at(-1)[1], unit);
+  const latest = series.flatMap(item => {
+    const points = Array.isArray(item.points) ? item.points : [];
+    return points.length ? [{ label: item.label, point: points.at(-1) }] : [];
+  });
+  if (!latest.length) return "No data";
+  if (latest.length === 1) return formatter(latest[0].point[1], unit);
+  if (latest.length === 2) {
+    return latest
+      .map(item => `${item.label} ${formatter(item.point[1], unit)}`)
+      .join(" · ");
+  }
+  return `${latest.length} series`;
 };
 
 export const formatChartValue = (value, unit) => {
   if (!Number.isFinite(value)) return "—";
-  if (unit === "bytes") {
+  if (unit === "bytes" || unit === "bytes/s") {
     const absolute = Math.abs(value);
-    if (absolute >= 1048576) return `${(value / 1048576).toFixed(1)} MB`;
-    if (absolute >= 1024) return `${(value / 1024).toFixed(1)} KB`;
-    return `${Math.round(value)} B`;
+    const suffix = unit === "bytes/s" ? "/s" : "";
+    if (absolute >= 1048576) return `${(value / 1048576).toFixed(1)} MB${suffix}`;
+    if (absolute >= 1024) return `${(value / 1024).toFixed(1)} KB${suffix}`;
+    return `${Math.round(value)} B${suffix}`;
   }
   if (unit === "reductions/s") return `${Math.round(value).toLocaleString()} /s`;
   if (unit === "ms") return `${Math.round(value)} ms`;

--- a/assets/test/client-contracts.test.mjs
+++ b/assets/test/client-contracts.test.mjs
@@ -94,16 +94,20 @@ test("chart headline distinguishes a value from multiple series", () => {
   );
   assert.equal(
     chartHeadline(
-      [{ points: [[1, 1, 0]] }, { points: [[1, 2, 0]] }],
+      [
+        { label: "Input", points: [[1, 1, 0]] },
+        { label: "Output", points: [[1, 2, 0]] }
+      ],
       "bytes",
       format
     ),
-    "2 series"
+    "Input 1 bytes · Output 2 bytes"
   );
 });
 
 test("chart values preserve percentage units", () => {
   assert.equal(formatChartValue(11.77, "%"), "11.8%");
+  assert.equal(formatChartValue(2048, "bytes/s"), "2.0 KB/s");
 });
 
 test("chart domains honor meaningful fixed bounds", () => {
@@ -328,6 +332,10 @@ test("runtime summary adapts before cards become cramped", async () => {
   assert.match(
     stylesheet,
     /\.beam-console-runtime-summary\s*\{[\s\S]*?grid-template-columns:\s*repeat\(auto-fit, minmax\(150px, 1fr\)\)/
+  );
+  assert.match(
+    stylesheet,
+    /@media \(max-width: 760px\)[\s\S]*?\.beam-console-runtime-summary\s*\{[\s\S]*?display:\s*flex[\s\S]*?overflow-x:\s*auto/
   );
 });
 

--- a/lib/beam_console/runtime/local.ex
+++ b/lib/beam_console/runtime/local.ex
@@ -17,8 +17,9 @@ defmodule BeamConsole.Runtime.Local do
   alias BeamConsole.ProcessDetail.Diagnostics
   alias BeamConsole.ProcessInfo
   alias BeamConsole.ProcessRelation
-  alias BeamConsole.Runtime.Sample, as: RuntimeSample
   alias BeamConsole.Runtime.ProcessSelector
+  alias BeamConsole.Runtime.Pressure
+  alias BeamConsole.Runtime.Sample, as: RuntimeSample
   alias BeamConsole.Runtime.Supervision
   alias BeamConsole.Snapshot
 
@@ -528,6 +529,7 @@ defmodule BeamConsole.Runtime.Local do
          coverage
        ) do
     memory = :erlang.memory()
+    pressure = runtime_pressure()
 
     %RuntimeSample{
       sequence: sequence,
@@ -537,7 +539,7 @@ defmodule BeamConsole.Runtime.Local do
       inspected_process_count: coverage.inspected_pids,
       supervisor_count: supervisor_count(applications, edges),
       application_count: map_size(applications),
-      ets_count: length(:ets.all()),
+      ets_count: system_info_integer(:ets_count) || 0,
       node_count: map_size(nodes),
       atom_count: :erlang.system_info(:atom_count),
       atom_limit: :erlang.system_info(:atom_limit),
@@ -548,11 +550,87 @@ defmodule BeamConsole.Runtime.Local do
       memory_binary: memory[:binary],
       memory_code: memory[:code],
       memory_ets: memory[:ets],
-      scheduler_count: :erlang.system_info(:schedulers_online),
-      run_queue: :erlang.statistics(:run_queue),
+      scheduler_count: pressure.scheduler_online,
+      run_queue: pressure.run_queue_total,
+      pressure: pressure,
       collector_scan_ms: coverage.duration_ms,
       collector_partial?: Coverage.state(coverage) != :complete
     }
+  end
+
+  defp runtime_pressure do
+    scheduler_total = system_info_integer(:schedulers)
+    scheduler_online = system_info_integer(:schedulers_online)
+    {run_queue_total, run_queue_cpu, run_queue_io} = run_queues(scheduler_total)
+    {io_input_bytes, io_output_bytes} = io_counters()
+
+    %Pressure{
+      uptime_ms: uptime_ms(),
+      port_count: system_info_integer(:port_count),
+      port_limit: system_info_integer(:port_limit),
+      process_limit: system_info_integer(:process_limit),
+      scheduler_total: scheduler_total,
+      scheduler_online: scheduler_online,
+      dirty_cpu_scheduler_total: system_info_integer(:dirty_cpu_schedulers),
+      dirty_cpu_scheduler_online: system_info_integer(:dirty_cpu_schedulers_online),
+      dirty_io_scheduler_total: system_info_integer(:dirty_io_schedulers),
+      run_queue_total: run_queue_total,
+      run_queue_cpu: run_queue_cpu,
+      run_queue_io: run_queue_io,
+      io_input_bytes: io_input_bytes,
+      io_output_bytes: io_output_bytes
+    }
+  end
+
+  defp system_info_integer(key) do
+    key
+    |> :erlang.system_info()
+    |> non_negative_integer()
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp statistics_integer(key) do
+    key
+    |> :erlang.statistics()
+    |> non_negative_integer()
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp uptime_ms do
+    started_at = :erlang.system_info(:start_time)
+    elapsed = :erlang.monotonic_time() - started_at
+    :erlang.convert_time_unit(elapsed, :native, :millisecond)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp io_counters do
+    {{:input, input}, {:output, output}} = :erlang.statistics(:io)
+    {non_negative_integer(input), non_negative_integer(output)}
+  rescue
+    ArgumentError -> {nil, nil}
+  end
+
+  defp run_queues(scheduler_total)
+       when is_integer(scheduler_total) and scheduler_total > 0 do
+    lengths = :erlang.statistics(:run_queue_lengths_all)
+
+    case Pressure.partition_run_queues(lengths, scheduler_total) do
+      {:ok, queues} -> {queues.total, queues.cpu, queues.io}
+      :error -> fallback_run_queues()
+    end
+  rescue
+    ArgumentError -> fallback_run_queues()
+  end
+
+  defp run_queues(_scheduler_total) do
+    fallback_run_queues()
+  end
+
+  defp fallback_run_queues do
+    {statistics_integer(:run_queue), nil, nil}
   end
 
   defp supervisor_count(applications, edges) do

--- a/lib/beam_console/runtime/pressure.ex
+++ b/lib/beam_console/runtime/pressure.ex
@@ -1,0 +1,78 @@
+defmodule BeamConsole.Runtime.Pressure do
+  @moduledoc """
+  Stores low-overhead, node-wide runtime pressure measurements.
+
+  Values are fixed-shape scalars collected from public ERTS APIs. The struct
+  excludes scheduler-wall-time data, allocator details, port and socket
+  identities, paths, and other runtime terms that would add cost or expose host
+  details.
+  """
+
+  defstruct uptime_ms: nil,
+            port_count: nil,
+            port_limit: nil,
+            process_limit: nil,
+            scheduler_total: nil,
+            scheduler_online: nil,
+            dirty_cpu_scheduler_total: nil,
+            dirty_cpu_scheduler_online: nil,
+            dirty_io_scheduler_total: nil,
+            run_queue_total: nil,
+            run_queue_cpu: nil,
+            run_queue_io: nil,
+            io_input_bytes: nil,
+            io_output_bytes: nil
+
+  @type measurement :: non_neg_integer() | nil
+  @type run_queues :: %{
+          total: non_neg_integer(),
+          cpu: non_neg_integer(),
+          io: non_neg_integer()
+        }
+  @type t :: %__MODULE__{
+          uptime_ms: measurement(),
+          port_count: measurement(),
+          port_limit: measurement(),
+          process_limit: measurement(),
+          scheduler_total: measurement(),
+          scheduler_online: measurement(),
+          dirty_cpu_scheduler_total: measurement(),
+          dirty_cpu_scheduler_online: measurement(),
+          dirty_io_scheduler_total: measurement(),
+          run_queue_total: measurement(),
+          run_queue_cpu: measurement(),
+          run_queue_io: measurement(),
+          io_input_bytes: measurement(),
+          io_output_bytes: measurement()
+        }
+
+  @doc """
+  Partitions configured, dirty CPU, and dirty I/O run-queue lengths.
+
+  ERTS returns one normal queue per configured scheduler followed by one shared
+  dirty CPU queue and one shared dirty I/O queue.
+
+  ## Examples
+
+      iex> BeamConsole.Runtime.Pressure.partition_run_queues([1, 2, 3, 4], 2)
+      {:ok, %{total: 10, cpu: 6, io: 4}}
+  """
+  @spec partition_run_queues([non_neg_integer()], pos_integer()) ::
+          {:ok, run_queues()} | :error
+  def partition_run_queues(lengths, scheduler_total)
+      when is_list(lengths) and is_integer(scheduler_total) and scheduler_total > 0 do
+    with true <- length(lengths) == scheduler_total + 2,
+         true <- Enum.all?(lengths, &(is_integer(&1) and &1 >= 0)),
+         {normal_queues, [dirty_cpu_queue, dirty_io_queue]} <-
+           Enum.split(lengths, scheduler_total) do
+      cpu = Enum.sum(normal_queues) + dirty_cpu_queue
+      {:ok, %{total: cpu + dirty_io_queue, cpu: cpu, io: dirty_io_queue}}
+    else
+      _other -> :error
+    end
+  end
+
+  def partition_run_queues(_lengths, _scheduler_total) do
+    :error
+  end
+end

--- a/lib/beam_console/runtime/sample.ex
+++ b/lib/beam_console/runtime/sample.ex
@@ -6,6 +6,8 @@ defmodule BeamConsole.Runtime.Sample do
   runtime terms, process identifiers, and host paths.
   """
 
+  alias BeamConsole.Runtime.Pressure
+
   @enforce_keys [:sequence, :sampled_at_ms, :monotonic_ms]
   defstruct sequence: 0,
             segment: 0,
@@ -28,6 +30,7 @@ defmodule BeamConsole.Runtime.Sample do
             memory_ets: nil,
             scheduler_count: nil,
             run_queue: nil,
+            pressure: nil,
             collector_scan_ms: nil,
             collector_partial?: false
 
@@ -53,6 +56,7 @@ defmodule BeamConsole.Runtime.Sample do
           memory_ets: non_neg_integer() | nil,
           scheduler_count: pos_integer() | nil,
           run_queue: non_neg_integer() | nil,
+          pressure: Pressure.t() | nil,
           collector_scan_ms: non_neg_integer() | nil,
           collector_partial?: boolean()
         }

--- a/lib/beam_console/series/downsampler.ex
+++ b/lib/beam_console/series/downsampler.ex
@@ -9,7 +9,7 @@ defmodule BeamConsole.Series.Downsampler do
   @type point :: %{
           required(:sampled_at_ms) => integer(),
           required(:value) => number(),
-          optional(:segment) => non_neg_integer()
+          optional(:segment) => non_neg_integer() | String.t()
         }
 
   @doc """

--- a/lib/beam_console_web/components/stats_components.ex
+++ b/lib/beam_console_web/components/stats_components.ex
@@ -80,9 +80,12 @@ if Code.ensure_loaded?(Phoenix.Component) do
           <div class="beam-console-recorder-summary beam-console-runtime-summary">
             <div>
               <span>Processes</span>
-              <strong>{@summary.process_count}</strong>
+              <strong>{format_integer(@summary.process_count)}</strong>
               <small :if={@summary.inspected_process_count < @summary.process_count}>
-                {@summary.inspected_process_count} inspected by the bounded collector
+                {format_integer(@summary.inspected_process_count)} inspected by the bounded collector
+              </small>
+              <small :if={@summary.process_limit}>
+                {capacity(@summary.process_limit, @summary.process_utilization)}
               </small>
             </div>
             <div><span>Supervisors</span><strong>{@summary.supervisor_count}</strong></div>
@@ -98,8 +101,35 @@ if Code.ensure_loaded?(Phoenix.Component) do
                 {atom_capacity(@summary.atom_limit, @summary.atom_utilization)}. Atoms persist for the VM lifetime.
               </small>
             </div>
+            <div>
+              <span>Ports</span>
+              <strong>{capacity_count(@summary.port_count, @summary.port_limit)}</strong>
+              <small>{capacity_usage(@summary.port_utilization)}</small>
+            </div>
+            <div>
+              <span>Schedulers</span>
+              <strong>{scheduler_capacity(@summary.scheduler_online, @summary.scheduler_total)}</strong>
+              <small>
+                {dirty_schedulers(
+                  @summary.dirty_cpu_scheduler_online,
+                  @summary.dirty_cpu_scheduler_total,
+                  @summary.dirty_io_scheduler_total
+                )}
+              </small>
+            </div>
             <div><span>ETS tables</span><strong>{@summary.ets_count}</strong></div>
-            <div><span>Run queue</span><strong>{@summary.run_queue || "—"}</strong></div>
+            <div>
+              <span>Run queue</span><strong>{format_optional_number(@summary.run_queue)}</strong>
+              <small>{run_queue_split(@summary.run_queue_cpu, @summary.run_queue_io)}</small>
+            </div>
+            <div>
+              <span>I/O throughput</span>
+              <strong>
+                {io_throughput(@summary.io_input_per_second, @summary.io_output_per_second)}
+              </strong>
+              <small>input · output per second</small>
+            </div>
+            <div><span>Uptime</span><strong>{format_uptime(@summary.uptime_ms)}</strong></div>
           </div>
 
           <div class="beam-console-tab-scroll">
@@ -111,6 +141,7 @@ if Code.ensure_loaded?(Phoenix.Component) do
               ids={[
                 "runtime-memory",
                 "runtime-run-queue",
+                "runtime-io",
                 "runtime-counts",
                 "runtime-scan",
                 "runtime-atoms"
@@ -176,6 +207,85 @@ if Code.ensure_loaded?(Phoenix.Component) do
 
     defp atom_capacity(_limit, _utilization) do
       "Limit unavailable"
+    end
+
+    defp capacity(limit, utilization) when is_integer(limit) do
+      "of #{format_integer(limit)} · #{capacity_usage(utilization)}"
+    end
+
+    defp capacity(_limit, _utilization) do
+      "Limit unavailable"
+    end
+
+    defp capacity_count(count, limit) when is_integer(count) and is_integer(limit) do
+      "#{format_integer(count)} of #{format_integer(limit)}"
+    end
+
+    defp capacity_count(_count, _limit) do
+      "—"
+    end
+
+    defp capacity_usage(utilization) when is_number(utilization) do
+      "#{format_percentage(utilization)} used"
+    end
+
+    defp capacity_usage(_utilization) do
+      "Usage unavailable"
+    end
+
+    defp scheduler_capacity(online, total) when is_integer(online) and is_integer(total) do
+      "#{format_integer(online)} of #{format_integer(total)} online"
+    end
+
+    defp scheduler_capacity(_online, _total) do
+      "—"
+    end
+
+    defp dirty_schedulers(cpu_online, cpu_total, io_total)
+         when is_integer(cpu_online) and is_integer(cpu_total) and is_integer(io_total) do
+      "Dirty CPU #{cpu_online}/#{cpu_total} · Dirty I/O #{io_total}"
+    end
+
+    defp dirty_schedulers(_cpu_online, _cpu_total, _io_total) do
+      "Dirty scheduler topology unavailable"
+    end
+
+    defp run_queue_split(cpu, io) when is_integer(cpu) and is_integer(io) do
+      "CPU #{format_integer(cpu)} · I/O #{format_integer(io)}"
+    end
+
+    defp run_queue_split(_cpu, _io) do
+      "Queue split unavailable"
+    end
+
+    defp io_throughput(input, output) do
+      "In #{format_rate(input)} · Out #{format_rate(output)}"
+    end
+
+    defp format_rate(nil) do
+      "—"
+    end
+
+    defp format_rate(value) do
+      "#{format_bytes(value)}/s"
+    end
+
+    defp format_uptime(milliseconds) when is_integer(milliseconds) and milliseconds >= 0 do
+      total_minutes = div(milliseconds, 60_000)
+      days = div(total_minutes, 1_440)
+      hours = total_minutes |> rem(1_440) |> div(60)
+      minutes = rem(total_minutes, 60)
+
+      cond do
+        days > 0 -> "#{days}d #{hours}h #{minutes}m"
+        hours > 0 -> "#{hours}h #{minutes}m"
+        total_minutes > 0 -> "#{minutes}m"
+        true -> "#{div(milliseconds, 1_000)}s"
+      end
+    end
+
+    defp format_uptime(_milliseconds) do
+      "—"
     end
 
     defp format_percentage(value) do

--- a/lib/beam_console_web/console/adjacent_rate_presenter.ex
+++ b/lib/beam_console_web/console/adjacent_rate_presenter.ex
@@ -1,0 +1,97 @@
+defmodule BeamConsoleWeb.Console.AdjacentRatePresenter do
+  @moduledoc """
+  Derives bounded rates from adjacent cumulative recorder counters.
+
+  Rates are emitted only within one recorder segment and when elapsed time and
+  both counters are valid. Every invalid transition starts a new chart segment,
+  so gaps, resets, missing values, and counter regressions remain visible.
+  """
+
+  alias BeamConsole.Recorder.Frame
+  alias BeamConsole.Series.Downsampler
+  alias BeamConsoleWeb.Console.ChartPresenter
+
+  @type counter_getter :: (Frame.t() -> non_neg_integer() | nil)
+
+  @doc "Builds one gap-aware, downsampled rate series from newest-first frames."
+  @spec series([Frame.t()], ChartPresenter.series_definition(), counter_getter()) :: map()
+  def series(frames, definition, counter_getter) when is_function(counter_getter, 1) do
+    point_limit = Map.fetch!(definition, :point_limit)
+
+    points =
+      frames
+      |> Enum.reverse()
+      |> rate_points(counter_getter)
+      |> Downsampler.downsample(point_limit)
+      |> Enum.map(&[&1.sampled_at_ms, &1.value, &1.segment])
+
+    definition
+    |> Map.delete(:point_limit)
+    |> Map.put(:points, points)
+  end
+
+  @doc "Returns the rate for the latest adjacent frame pair, or `nil` across a discontinuity."
+  @spec latest([Frame.t()], counter_getter()) :: number() | nil
+  def latest([current, previous | _frames], counter_getter)
+      when is_function(counter_getter, 1) do
+    case transition(previous, current, counter_getter) do
+      {:ok, rate} -> rate
+      :error -> nil
+    end
+  end
+
+  def latest(_frames, counter_getter) when is_function(counter_getter, 1) do
+    nil
+  end
+
+  defp rate_points([], _counter_getter) do
+    []
+  end
+
+  defp rate_points([first | rest], counter_getter) do
+    initial = %{previous: first, discontinuity: 0, points: []}
+
+    rest
+    |> Enum.reduce(initial, &rate_point(&1, &2, counter_getter))
+    |> Map.fetch!(:points)
+    |> Enum.reverse()
+  end
+
+  defp rate_point(current, state, counter_getter) do
+    case transition(state.previous, current, counter_getter) do
+      {:ok, rate} ->
+        point = %{
+          sampled_at_ms: current.sampled_at_ms,
+          value: rate,
+          segment: rate_segment(current.segment, state.discontinuity)
+        }
+
+        %{state | previous: current, points: [point | state.points]}
+
+      :error ->
+        %{state | previous: current, discontinuity: state.discontinuity + 1}
+    end
+  end
+
+  defp transition(previous, current, counter_getter) do
+    previous_counter = counter_getter.(previous)
+    current_counter = counter_getter.(current)
+    elapsed_ms = current.monotonic_ms - previous.monotonic_ms
+
+    if current.segment == previous.segment and elapsed_ms > 0 and
+         valid_counter?(previous_counter) and valid_counter?(current_counter) and
+         current_counter >= previous_counter do
+      {:ok, (current_counter - previous_counter) * 1_000 / elapsed_ms}
+    else
+      :error
+    end
+  end
+
+  defp valid_counter?(counter) do
+    is_integer(counter) and counter >= 0
+  end
+
+  defp rate_segment(segment, discontinuity) do
+    "#{segment}:#{discontinuity}"
+  end
+end

--- a/lib/beam_console_web/console/runtime_presenter.ex
+++ b/lib/beam_console_web/console/runtime_presenter.ex
@@ -3,22 +3,17 @@ defmodule BeamConsoleWeb.Console.RuntimePresenter do
 
   alias BeamConsole.Recorder.Frame
   alias BeamConsole.Recorder.Query
+  alias BeamConsole.Runtime.Pressure
   alias BeamConsole.Runtime.Sample
+  alias BeamConsoleWeb.Console.AdjacentRatePresenter
   alias BeamConsoleWeb.Console.ChartPresenter
 
-  @scalar_charts [
-    %{id: "runtime-run-queue", title: "Run queue", field: :run_queue, unit: "items"},
-    %{id: "runtime-scan", title: "Collector scan", field: :collector_scan_ms, unit: "ms"},
-    %{
-      id: "runtime-atoms",
-      title: "Atom table utilization",
-      label: "Atoms",
-      field: :atom_utilization,
-      unit: "%",
-      min: 0,
-      max: 100
-    }
-  ]
+  @scan_chart %{
+    id: "runtime-scan",
+    title: "Collector scan",
+    field: :collector_scan_ms,
+    unit: "ms"
+  }
 
   @doc "Builds the Runtime view without storing historical point arrays in LiveView assigns."
   @spec present(Query.t(), non_neg_integer()) :: map()
@@ -27,62 +22,122 @@ defmodule BeamConsoleWeb.Console.RuntimePresenter do
     latest = Enum.find_value(frames, & &1.runtime)
 
     %{
-      summary: summary(latest, query),
+      summary: summary(latest, frames, query),
       charts: charts(frames, revision, query.chart_points_limit)
     }
   end
 
-  defp summary(nil, query) do
+  @doc "Returns the complete zero-value contract used before a runtime sample is available."
+  @spec empty_summary() :: map()
+  def empty_summary do
     %{
       process_count: 0,
       inspected_process_count: 0,
       supervisor_count: 0,
+      application_count: 0,
       ets_count: 0,
-      run_queue: nil,
+      node_count: 0,
       atom_count: nil,
       atom_limit: nil,
       atom_utilization: nil,
+      memory_total: nil,
+      uptime_ms: nil,
+      port_count: nil,
+      port_limit: nil,
+      port_utilization: nil,
+      process_limit: nil,
+      process_utilization: nil,
+      scheduler_count: nil,
+      scheduler_total: nil,
+      scheduler_online: nil,
+      dirty_cpu_scheduler_total: nil,
+      dirty_cpu_scheduler_online: nil,
+      dirty_io_scheduler_total: nil,
+      run_queue: nil,
+      run_queue_total: nil,
+      run_queue_cpu: nil,
+      run_queue_io: nil,
+      io_input_per_second: nil,
+      io_output_per_second: nil,
+      collector_scan_ms: nil,
       collector_partial?: false,
-      omitted: query.omitted + query.dropped
+      omitted: 0
     }
   end
 
-  defp summary(%Sample{} = sample, query) do
+  defp summary(nil, _frames, query) do
+    Map.put(empty_summary(), :omitted, query.omitted + query.dropped)
+  end
+
+  defp summary(%Sample{} = sample, frames, query) do
+    pressure = Map.get(sample, :pressure)
     atom_count = Map.get(sample, :atom_count)
     atom_limit = Map.get(sample, :atom_limit)
+    process_count = Map.get(sample, :process_count, 0)
+    process_limit = pressure_value(pressure, :process_limit)
+    port_count = pressure_value(pressure, :port_count)
+    port_limit = pressure_value(pressure, :port_limit)
 
-    sample
-    |> Map.take([
-      :process_count,
-      :inspected_process_count,
-      :supervisor_count,
-      :application_count,
-      :ets_count,
-      :node_count,
-      :atom_count,
-      :atom_limit,
-      :memory_total,
-      :run_queue,
-      :scheduler_count,
-      :collector_scan_ms,
-      :collector_partial?
-    ])
+    empty_summary()
+    |> Map.merge(
+      Map.take(sample, [
+        :process_count,
+        :inspected_process_count,
+        :supervisor_count,
+        :application_count,
+        :ets_count,
+        :node_count,
+        :atom_count,
+        :atom_limit,
+        :memory_total,
+        :run_queue,
+        :scheduler_count,
+        :collector_scan_ms,
+        :collector_partial?
+      ])
+    )
+    |> Map.merge(pressure_summary(pressure))
     |> Map.put(:atom_count, atom_count)
     |> Map.put(:atom_limit, atom_limit)
-    |> Map.put(:atom_utilization, atom_utilization(atom_count, atom_limit))
+    |> Map.put(:atom_utilization, utilization(atom_count, atom_limit))
+    |> Map.put(:process_utilization, utilization(process_count, process_limit))
+    |> Map.put(:port_utilization, utilization(port_count, port_limit))
+    |> Map.put(:io_input_per_second, latest_io_rate(frames, :io_input_bytes))
+    |> Map.put(:io_output_per_second, latest_io_rate(frames, :io_output_bytes))
     |> Map.put(:omitted, query.omitted + query.dropped)
   end
 
-  defp charts(frames, revision, point_limit) do
-    scalar_charts =
-      Enum.map(@scalar_charts, &scalar_chart(frames, revision, point_limit, &1))
+  defp pressure_summary(%Pressure{} = pressure) do
+    pressure
+    |> Map.from_struct()
+    |> Map.take([
+      :uptime_ms,
+      :port_count,
+      :port_limit,
+      :process_limit,
+      :scheduler_total,
+      :scheduler_online,
+      :dirty_cpu_scheduler_total,
+      :dirty_cpu_scheduler_online,
+      :dirty_io_scheduler_total,
+      :run_queue_total,
+      :run_queue_cpu,
+      :run_queue_io
+    ])
+  end
 
+  defp pressure_summary(_pressure) do
+    %{}
+  end
+
+  defp charts(frames, revision, point_limit) do
     [
       memory_chart(frames, revision, point_limit),
-      Enum.at(scalar_charts, 0),
+      run_queue_chart(frames, revision, point_limit),
+      io_chart(frames, revision, point_limit),
       count_chart(frames, revision, point_limit),
-      Enum.at(scalar_charts, 1),
-      Enum.at(scalar_charts, 2)
+      scalar_chart(frames, revision, point_limit, @scan_chart),
+      capacity_chart(frames, revision, point_limit)
     ]
   end
 
@@ -106,6 +161,44 @@ defmodule BeamConsoleWeb.Console.RuntimePresenter do
     ChartPresenter.chart(definition, series, revision)
   end
 
+  defp run_queue_chart(frames, revision, point_limit) do
+    fields = [
+      {:total, "Total", :run_queue_total},
+      {:cpu, "CPU", :run_queue_cpu},
+      {:io, "I/O", :run_queue_io}
+    ]
+
+    series =
+      Enum.map(fields, fn {key, label, field} ->
+        definition = %{key: key, label: label, unit: "items", point_limit: point_limit}
+        ChartPresenter.series(frames, definition, &run_queue_value(&1, field))
+      end)
+
+    definition = %{id: "runtime-run-queue", title: "Run queues", unit: "items"}
+    ChartPresenter.chart(definition, series, revision)
+  end
+
+  defp io_chart(frames, revision, point_limit) do
+    fields = [
+      {:input, "Input", :io_input_bytes},
+      {:output, "Output", :io_output_bytes}
+    ]
+
+    series =
+      Enum.map(fields, fn {key, label, field} ->
+        definition = %{key: key, label: label, unit: "bytes/s", point_limit: point_limit}
+
+        AdjacentRatePresenter.series(
+          frames,
+          definition,
+          &runtime_pressure_value(&1, field)
+        )
+      end)
+
+    definition = %{id: "runtime-io", title: "I/O throughput", unit: "bytes/s"}
+    ChartPresenter.chart(definition, series, revision)
+  end
+
   defp count_chart(frames, revision, point_limit) do
     fields = [
       {:process_count, "Processes"},
@@ -125,6 +218,35 @@ defmodule BeamConsoleWeb.Console.RuntimePresenter do
     ChartPresenter.chart(definition, series, revision)
   end
 
+  defp capacity_chart(frames, revision, point_limit) do
+    fields = [
+      {:process_utilization, "Processes", :process_count, :process_limit},
+      {:port_utilization, "Ports", :port_count, :port_limit},
+      {:atom_utilization, "Atoms", :atom_count, :atom_limit}
+    ]
+
+    series =
+      Enum.map(fields, fn {key, label, count_field, limit_field} ->
+        definition = %{key: key, label: label, unit: "%", point_limit: point_limit}
+
+        ChartPresenter.series(
+          frames,
+          definition,
+          &capacity_value(&1, count_field, limit_field)
+        )
+      end)
+
+    definition = %{
+      id: "runtime-atoms",
+      title: "Runtime capacity",
+      unit: "%",
+      min: 0,
+      max: 100
+    }
+
+    ChartPresenter.chart(definition, series, revision)
+  end
+
   defp scalar_chart(frames, revision, point_limit, definition) do
     series_definition = %{
       key: definition.field,
@@ -140,24 +262,68 @@ defmodule BeamConsoleWeb.Console.RuntimePresenter do
     ChartPresenter.chart(chart_definition, [series], revision)
   end
 
-  defp runtime_value(%Frame{runtime: %Sample{} = sample}, :atom_utilization) do
-    atom_utilization(Map.get(sample, :atom_count), Map.get(sample, :atom_limit))
+  defp capacity_value(frame, :atom_count, :atom_limit) do
+    utilization(runtime_value(frame, :atom_count), runtime_value(frame, :atom_limit))
+  end
+
+  defp capacity_value(frame, :process_count, :process_limit) do
+    utilization(
+      runtime_value(frame, :process_count),
+      runtime_pressure_value(frame, :process_limit)
+    )
+  end
+
+  defp capacity_value(frame, :port_count, :port_limit) do
+    utilization(
+      runtime_pressure_value(frame, :port_count),
+      runtime_pressure_value(frame, :port_limit)
+    )
+  end
+
+  defp run_queue_value(frame, :run_queue_total) do
+    runtime_pressure_value(frame, :run_queue_total) || runtime_value(frame, :run_queue)
+  end
+
+  defp run_queue_value(frame, field) do
+    runtime_pressure_value(frame, field)
   end
 
   defp runtime_value(%Frame{runtime: %Sample{} = sample}, field) do
-    Map.fetch!(sample, field)
+    Map.get(sample, field)
   end
 
   defp runtime_value(_frame, _field) do
     nil
   end
 
-  defp atom_utilization(count, limit)
+  defp runtime_pressure_value(%Frame{runtime: %Sample{} = sample}, field) do
+    sample
+    |> Map.get(:pressure)
+    |> pressure_value(field)
+  end
+
+  defp runtime_pressure_value(_frame, _field) do
+    nil
+  end
+
+  defp pressure_value(%Pressure{} = pressure, field) do
+    Map.get(pressure, field)
+  end
+
+  defp pressure_value(_pressure, _field) do
+    nil
+  end
+
+  defp latest_io_rate(frames, field) do
+    AdjacentRatePresenter.latest(frames, &runtime_pressure_value(&1, field))
+  end
+
+  defp utilization(count, limit)
        when is_integer(count) and is_integer(limit) and limit > 0 do
     count / limit * 100
   end
 
-  defp atom_utilization(_count, _limit) do
+  defp utilization(_count, _limit) do
     nil
   end
 end

--- a/lib/beam_console_web/console_live.ex
+++ b/lib/beam_console_web/console_live.ex
@@ -78,7 +78,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         |> assign(:lifecycle_meta, %{empty?: true, omitted: 0})
         |> assign(:activity_summary, empty_activity_summary())
         |> assign(:activity_has_samples?, false)
-        |> assign(:runtime_summary, empty_runtime_summary())
+        |> assign(:runtime_summary, RuntimePresenter.empty_summary())
         |> assign(:runtime_has_samples?, false)
         |> assign(:process_stream_order, [])
         |> assign(:lifecycle_stream_ids, MapSet.new())
@@ -762,21 +762,6 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp empty_activity_summary do
       %{reductions_per_second: 0, mailbox_delta: 0, memory_delta: 0, omitted: 0}
-    end
-
-    defp empty_runtime_summary do
-      %{
-        process_count: 0,
-        inspected_process_count: 0,
-        supervisor_count: 0,
-        ets_count: 0,
-        run_queue: nil,
-        atom_count: nil,
-        atom_limit: nil,
-        atom_utilization: nil,
-        collector_partial?: false,
-        omitted: 0
-      }
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BeamConsole.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ccarvalho-eng/beam_console"
-  @version "0.4.0"
+  @version "0.5.0"
 
   def project do
     [

--- a/priv/static/beam_console.css
+++ b/priv/static/beam_console.css
@@ -1599,6 +1599,19 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .beam-console-runtime-summary {
+    display: flex;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: inline proximity;
+  }
+
+  .beam-console-runtime-summary > div {
+    min-width: min(180px, 72vw);
+    flex: 0 0 min(180px, 72vw);
+    scroll-snap-align: start;
+  }
+
   .beam-console-chart-grid {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/priv/static/beam_console_support.mjs
+++ b/priv/static/beam_console_support.mjs
@@ -48,19 +48,28 @@ export const writeStoredBranchStates = (storageOwner, key, states) => {
 };
 
 export const chartHeadline = (series, unit, formatter) => {
-  const points = series.flatMap(item => Array.isArray(item.points) ? item.points : []);
-  if (!points.length) return "No data";
-  if (series.length > 1) return `${series.length} series`;
-  return formatter(series[0].points.at(-1)[1], unit);
+  const latest = series.flatMap(item => {
+    const points = Array.isArray(item.points) ? item.points : [];
+    return points.length ? [{ label: item.label, point: points.at(-1) }] : [];
+  });
+  if (!latest.length) return "No data";
+  if (latest.length === 1) return formatter(latest[0].point[1], unit);
+  if (latest.length === 2) {
+    return latest
+      .map(item => `${item.label} ${formatter(item.point[1], unit)}`)
+      .join(" · ");
+  }
+  return `${latest.length} series`;
 };
 
 export const formatChartValue = (value, unit) => {
   if (!Number.isFinite(value)) return "—";
-  if (unit === "bytes") {
+  if (unit === "bytes" || unit === "bytes/s") {
     const absolute = Math.abs(value);
-    if (absolute >= 1048576) return `${(value / 1048576).toFixed(1)} MB`;
-    if (absolute >= 1024) return `${(value / 1024).toFixed(1)} KB`;
-    return `${Math.round(value)} B`;
+    const suffix = unit === "bytes/s" ? "/s" : "";
+    if (absolute >= 1048576) return `${(value / 1048576).toFixed(1)} MB${suffix}`;
+    if (absolute >= 1024) return `${(value / 1024).toFixed(1)} KB${suffix}`;
+    return `${Math.round(value)} B${suffix}`;
   }
   if (unit === "reductions/s") return `${Math.round(value).toLocaleString()} /s`;
   if (unit === "ms") return `${Math.round(value)} ms`;

--- a/test/beam_console/runtime/local_test.exs
+++ b/test/beam_console/runtime/local_test.exs
@@ -18,6 +18,25 @@ defmodule BeamConsole.Runtime.LocalTest do
     assert snapshot.runtime_sample.atom_count <= snapshot.runtime_sample.atom_limit
     assert snapshot.runtime_sample.memory_total > 0
     assert snapshot.runtime_sample.scheduler_count > 0
+
+    pressure = snapshot.runtime_sample.pressure
+
+    assert pressure.uptime_ms >= 0
+    assert pressure.port_count >= 0
+    assert pressure.port_count <= pressure.port_limit
+    assert pressure.process_limit == :erlang.system_info(:process_limit)
+    assert pressure.scheduler_total == :erlang.system_info(:schedulers)
+    assert pressure.scheduler_online == :erlang.system_info(:schedulers_online)
+    assert pressure.dirty_cpu_scheduler_total == :erlang.system_info(:dirty_cpu_schedulers)
+
+    assert pressure.dirty_cpu_scheduler_online ==
+             :erlang.system_info(:dirty_cpu_schedulers_online)
+
+    assert pressure.dirty_io_scheduler_total == :erlang.system_info(:dirty_io_schedulers)
+    assert pressure.run_queue_total >= pressure.run_queue_cpu
+    assert pressure.run_queue_io == pressure.run_queue_total - pressure.run_queue_cpu
+    assert pressure.io_input_bytes >= 0
+    assert pressure.io_output_bytes >= 0
     refute Enum.any?(snapshot.processes, fn {_id, process} -> process.pid == self() end)
     refute Enum.any?(snapshot.processes, fn {_id, process} -> process.label == "nil" end)
   end

--- a/test/beam_console/runtime/pressure_test.exs
+++ b/test/beam_console/runtime/pressure_test.exs
@@ -1,0 +1,20 @@
+defmodule BeamConsole.Runtime.PressureTest do
+  use ExUnit.Case, async: true
+
+  doctest BeamConsole.Runtime.Pressure
+
+  alias BeamConsole.Runtime.Pressure
+
+  test "partitions by configured schedulers when only a subset is online" do
+    lengths = [1, 2, 3, 4, 5, 6]
+
+    assert {:ok, queues} = Pressure.partition_run_queues(lengths, 4)
+    assert queues == %{total: 21, cpu: 15, io: 6}
+  end
+
+  test "rejects malformed or negative queue snapshots" do
+    assert Pressure.partition_run_queues([1, 2, 3], 2) == :error
+    assert Pressure.partition_run_queues([1, -1, 2, 3], 2) == :error
+    assert Pressure.partition_run_queues(:unavailable, 2) == :error
+  end
+end

--- a/test/beam_console_web/components/stats_components_test.exs
+++ b/test/beam_console_web/components/stats_components_test.exs
@@ -5,6 +5,7 @@ if Code.ensure_loaded?(Phoenix.LiveViewTest) do
     import Phoenix.LiveViewTest
 
     alias BeamConsoleWeb.Components.StatsComponents
+    alias BeamConsoleWeb.Console.RuntimePresenter
 
     test "renders readable and accessible atom table capacity" do
       summary = %{
@@ -14,9 +15,24 @@ if Code.ensure_loaded?(Phoenix.LiveViewTest) do
         collector_partial?: false,
         ets_count: 12,
         inspected_process_count: 300,
+        io_input_per_second: 2_048.0,
+        io_output_per_second: 4_096.0,
+        port_count: 17,
+        port_limit: 65_536,
+        port_utilization: 0.03,
         process_count: 345,
+        process_limit: 1_048_576,
+        process_utilization: 0.03,
         run_queue: 1,
-        supervisor_count: 23
+        run_queue_cpu: 1,
+        run_queue_io: 0,
+        scheduler_online: 8,
+        scheduler_total: 10,
+        dirty_cpu_scheduler_online: 4,
+        dirty_cpu_scheduler_total: 5,
+        dirty_io_scheduler_total: 3,
+        supervisor_count: 23,
+        uptime_ms: 93_784_000
       }
 
       html =
@@ -30,9 +46,29 @@ if Code.ensure_loaded?(Phoenix.LiveViewTest) do
       assert html =~ "300 inspected by the bounded collector"
       assert html =~ "of 1,048,576 · 11.77% used"
       assert html =~ "Atoms persist for the VM lifetime."
+      assert html =~ "17 of 65,536"
+      assert html =~ "8 of 10 online"
+      assert html =~ "CPU 1 · I/O 0"
+      assert html =~ "In 2.0 KB/s · Out 4.0 KB/s"
+      assert html =~ "1d 2h 3m"
       assert html =~ ~s(role="group")
       assert html =~ ~s(aria-labelledby="beam-console-atom-label")
       assert html =~ ~s(aria-describedby="beam-console-atom-description")
+    end
+
+    test "renders the complete unavailable runtime state without misleading utilization" do
+      html =
+        render_component(&StatsComponents.runtime/1,
+          summary: RuntimePresenter.empty_summary(),
+          has_samples?: false
+        )
+
+      assert html =~ "Limit unavailable"
+      assert html =~ "Usage unavailable"
+      assert html =~ "Dirty scheduler topology unavailable"
+      assert html =~ "Queue split unavailable"
+      assert html =~ "In — · Out —"
+      refute html =~ "% used"
     end
   end
 end

--- a/test/beam_console_web/console/adjacent_rate_presenter_test.exs
+++ b/test/beam_console_web/console/adjacent_rate_presenter_test.exs
@@ -1,0 +1,77 @@
+defmodule BeamConsoleWeb.Console.AdjacentRatePresenterTest do
+  use ExUnit.Case, async: true
+
+  alias BeamConsole.Recorder.Frame
+  alias BeamConsole.Runtime.Pressure
+  alias BeamConsole.Runtime.Sample
+  alias BeamConsoleWeb.Console.AdjacentRatePresenter
+
+  test "derives rates only from valid adjacent frames and preserves discontinuities" do
+    frames = [
+      frame(1, 0, 1_000, 100),
+      frame(2, 0, 2_000, 300),
+      frame(3, 1, 3_000, 900),
+      frame(4, 1, 4_000, 1_000),
+      frame(5, 1, 4_000, 1_100),
+      frame(6, 1, 5_000, 900),
+      frame(7, 1, 6_000, nil),
+      frame(8, 1, 7_000, 1_200),
+      frame(9, 1, 8_000, 1_300)
+    ]
+
+    definition = %{key: :input, label: "Input", unit: "bytes/s", point_limit: 20}
+
+    series =
+      AdjacentRatePresenter.series(Enum.reverse(frames), definition, fn frame ->
+        frame.runtime.pressure.io_input_bytes
+      end)
+
+    assert Enum.map(series.points, &Enum.at(&1, 1)) == [200.0, 100.0, 100.0]
+    assert series.points |> Enum.map(&Enum.at(&1, 2)) |> Enum.uniq() |> length() == 3
+  end
+
+  test "caps derived points after calculating adjacent rates" do
+    frames =
+      for sequence <- 1..100 do
+        frame(sequence, 0, sequence * 1_000, sequence * 100)
+      end
+
+    definition = %{key: :input, label: "Input", unit: "bytes/s", point_limit: 7}
+
+    series =
+      AdjacentRatePresenter.series(Enum.reverse(frames), definition, fn frame ->
+        frame.runtime.pressure.io_input_bytes
+      end)
+
+    assert length(series.points) == 7
+  end
+
+  test "returns no latest rate across a segment boundary or counter regression" do
+    getter = fn frame -> frame.runtime.pressure.io_input_bytes end
+
+    assert AdjacentRatePresenter.latest(
+             [frame(2, 1, 2_000, 200), frame(1, 0, 1_000, 100)],
+             getter
+           ) == nil
+
+    assert AdjacentRatePresenter.latest(
+             [frame(2, 0, 2_000, 90), frame(1, 0, 1_000, 100)],
+             getter
+           ) == nil
+  end
+
+  defp frame(sequence, segment, monotonic_ms, counter) do
+    %Frame{
+      sequence: sequence,
+      segment: segment,
+      sampled_at_ms: monotonic_ms,
+      monotonic_ms: monotonic_ms,
+      runtime: %Sample{
+        sequence: sequence,
+        sampled_at_ms: monotonic_ms,
+        monotonic_ms: monotonic_ms,
+        pressure: %Pressure{io_input_bytes: counter}
+      }
+    }
+  end
+end

--- a/test/beam_console_web/console/stats_presenter_test.exs
+++ b/test/beam_console_web/console/stats_presenter_test.exs
@@ -4,6 +4,7 @@ defmodule BeamConsoleWeb.Console.StatsPresenterTest do
   alias BeamConsole.Activity.Sample, as: ActivitySample
   alias BeamConsole.Recorder.Frame
   alias BeamConsole.Recorder.Query
+  alias BeamConsole.Runtime.Pressure
   alias BeamConsole.Runtime.Sample, as: RuntimeSample
   alias BeamConsoleWeb.Console.ActivityPresenter
   alias BeamConsoleWeb.Console.RuntimePresenter
@@ -41,20 +42,63 @@ defmodule BeamConsoleWeb.Console.StatsPresenterTest do
   end
 
   test "runtime presentation reads only normalized runtime samples" do
-    runtime = %RuntimeSample{
+    first_runtime = %RuntimeSample{
       sequence: 1,
-      sampled_at_ms: 1,
-      monotonic_ms: 1,
-      process_count: 42,
+      sampled_at_ms: 1_000,
+      monotonic_ms: 1_000,
+      process_count: 40,
       inspected_process_count: 30,
       supervisor_count: 5,
       ets_count: 7,
       atom_count: 100,
       atom_limit: 1_000,
-      run_queue: 2
+      run_queue: 1,
+      pressure: %Pressure{
+        uptime_ms: 60_000,
+        port_count: 5,
+        port_limit: 100,
+        process_limit: 100,
+        scheduler_total: 8,
+        scheduler_online: 6,
+        dirty_cpu_scheduler_total: 4,
+        dirty_cpu_scheduler_online: 3,
+        dirty_io_scheduler_total: 2,
+        run_queue_total: 1,
+        run_queue_cpu: 1,
+        run_queue_io: 0,
+        io_input_bytes: 1_000,
+        io_output_bytes: 2_000
+      }
     }
 
-    result = RuntimePresenter.present(%Query{items: [frame(1, runtime: runtime)]}, 1)
+    latest_runtime = %{
+      first_runtime
+      | sequence: 2,
+        sampled_at_ms: 2_000,
+        monotonic_ms: 2_000,
+        process_count: 42,
+        run_queue: 2,
+        pressure: %{
+          first_runtime.pressure
+          | uptime_ms: 61_000,
+            run_queue_total: 2,
+            run_queue_cpu: 1,
+            run_queue_io: 1,
+            io_input_bytes: 1_300,
+            io_output_bytes: 2_500
+        }
+    }
+
+    result =
+      RuntimePresenter.present(
+        %Query{
+          items: [
+            frame(2, runtime: latest_runtime, sampled_at_ms: 2_000, monotonic_ms: 2_000),
+            frame(1, runtime: first_runtime, sampled_at_ms: 1_000, monotonic_ms: 1_000)
+          ]
+        },
+        2
+      )
 
     assert result.summary.process_count == 42
     assert result.summary.inspected_process_count == 30
@@ -62,12 +106,18 @@ defmodule BeamConsoleWeb.Console.StatsPresenterTest do
     assert result.summary.atom_limit == 1_000
     assert result.summary.atom_utilization == 10.0
     assert result.summary.run_queue == 2
-    assert length(result.charts) == 5
+    assert result.summary.port_utilization == 5.0
+    assert result.summary.process_utilization == 42.0
+    assert result.summary.io_input_per_second == 300.0
+    assert result.summary.io_output_per_second == 500.0
+    assert length(result.charts) == 6
 
     atom_chart = Enum.find(result.charts, &(&1.id == "runtime-atoms"))
 
-    assert atom_chart.series == [
-             %{key: :atom_utilization, label: "Atoms", unit: "%", points: [[1, 10.0, 0]]}
+    assert Enum.map(atom_chart.series, & &1.key) == [
+             :process_utilization,
+             :port_utilization,
+             :atom_utilization
            ]
 
     assert atom_chart.min == 0
@@ -75,6 +125,14 @@ defmodule BeamConsoleWeb.Console.StatsPresenterTest do
 
     count_chart = Enum.find(result.charts, &(&1.id == "runtime-counts"))
     assert Enum.any?(count_chart.series, &(&1.key == :inspected_process_count))
+
+    run_queue_chart = Enum.find(result.charts, &(&1.id == "runtime-run-queue"))
+    assert Enum.map(run_queue_chart.series, & &1.key) == [:total, :cpu, :io]
+
+    io_chart = Enum.find(result.charts, &(&1.id == "runtime-io"))
+    assert Enum.map(io_chart.series, & &1.key) == [:input, :output]
+    assert Enum.at(io_chart.series, 0).points |> List.last() |> Enum.at(1) == 300.0
+    assert Enum.at(io_chart.series, 1).points |> List.last() |> Enum.at(1) == 500.0
   end
 
   test "empty runtime presentation exposes the complete render contract" do
@@ -87,6 +145,8 @@ defmodule BeamConsoleWeb.Console.StatsPresenterTest do
     assert result.summary.atom_count == nil
     assert result.summary.atom_limit == nil
     assert result.summary.atom_utilization == nil
+    assert result.summary.port_count == nil
+    assert result.summary.io_input_per_second == nil
   end
 
   test "runtime presentation tolerates retained samples from before the atom fields" do
@@ -94,22 +154,25 @@ defmodule BeamConsoleWeb.Console.StatsPresenterTest do
       %RuntimeSample{sequence: 1, sampled_at_ms: 1, monotonic_ms: 1}
       |> Map.delete(:atom_count)
       |> Map.delete(:atom_limit)
+      |> Map.delete(:pressure)
 
     result = RuntimePresenter.present(%Query{items: [frame(1, runtime: legacy_runtime)]}, 1)
 
     assert result.summary.atom_count == nil
     assert result.summary.atom_limit == nil
     assert result.summary.atom_utilization == nil
+    assert result.summary.port_count == nil
+    assert result.summary.io_input_per_second == nil
 
     atom_chart = Enum.find(result.charts, &(&1.id == "runtime-atoms"))
-    assert atom_chart.series == [%{key: :atom_utilization, label: "Atoms", unit: "%", points: []}]
+    assert Enum.all?(atom_chart.series, &(&1.points == []))
   end
 
   defp frame(sequence, options) do
     %Frame{
       sequence: sequence,
-      sampled_at_ms: sequence,
-      monotonic_ms: sequence,
+      sampled_at_ms: Keyword.get(options, :sampled_at_ms, sequence),
+      monotonic_ms: Keyword.get(options, :monotonic_ms, sequence),
       activity: Keyword.get(options, :activity),
       runtime: Keyword.get(options, :runtime)
     }


### PR DESCRIPTION
## Summary

- add a fixed, scalar runtime pressure snapshot for process and port utilization, scheduler topology, run queues, uptime, and cumulative I/O
- derive gap-aware I/O throughput from adjacent recording frames without bridging pauses, counter resets, or collector discontinuities
- expand the Runtime view with compact cards and stable charts while preserving mobile and embedded layouts
- prepare the package and changelog for BeamConsole 0.5.0

## Safety and cost

- retain only bounded scalar values and cumulative counters
- read run-queue lengths once per sample and partition them by configured scheduler topology
- avoid scheduler wall-time collection, allocator scans, port identities, socket details, paths, endpoints, and raw runtime terms
- keep missing or legacy samples representable as unavailable data rather than fabricating rates