### PR TITLE
feat(console): add persistent focus mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.5.1 - 2026-08-28
+
+- Add a mount-scoped Focus mode that removes surrounding chrome without changing sampling or recording.
+- Add pre-paint persistence, cross-tab synchronization, accessible controls, and `F`/`Escape` shortcuts.
+
 ## 0.5.0 - 2026-08-27
 
 - Add bounded scheduling, heap, and garbage-collection diagnostics to the process inspector.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add BeamConsole to a Phoenix application:
 ```elixir
 def deps do
   [
-    {:beam_console, "~> 0.5.0"}
+    {:beam_console, "~> 0.5.1"}
   ]
 end
 ```
@@ -69,6 +69,7 @@ Call `BeamConsole.unsubscribe/0` when a long-lived manual subscriber no longer n
 - Activity: reductions per second, mailbox growth, memory movement, and ranked process movers.
 - Runtime: BEAM memory categories, CPU/I/O run queues, input/output throughput, process, port, and atom capacity, scheduler topology, uptime, runtime inventory, collector duration, applications, ETS tables, and connected-node inventory.
 - Inspector: allowlisted process, application, and node details, including scheduling, heap, and selected garbage-collection diagnostics. Process relationships and group leaders are clickable when their target is present in the latest sample.
+- Focus mode: hide navigation, hierarchy, recording controls, and summary cards without interrupting collection or recording. Press `F` to toggle it or `Escape` to leave it; the mount-scoped preference persists locally.
 
 Applications are grouped into host, dependencies, OTP, and tooling categories. Every tree branch can be collapsed and its state remains stable while LiveView updates.
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -406,7 +406,9 @@
 }
 
 .beam-console-panel-toggle,
-.beam-console-panel-backdrop {
+.beam-console-panel-backdrop,
+.beam-console-focus-inspector,
+.beam-console-focus-exit {
   display: none;
 }
 .beam-console-visually-hidden {

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -254,3 +254,134 @@
     transition-duration: 0.01ms !important;
   }
 }
+
+:root[data-beam-console-focus="true"] .beam-console-shell {
+  height: 100dvh;
+  padding: 0;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-frame {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  height: 100dvh;
+  min-height: 640px;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-header,
+:root[data-beam-console-focus="true"] .beam-console-sidebar,
+:root[data-beam-console-focus="true"] .beam-console-runtime-summary,
+:root[data-beam-console-focus="true"] .beam-console-recorder-summary {
+  display: none;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-main {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="false"]
+  .beam-console-inspector {
+  display: none;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="true"] {
+  grid-template-columns: minmax(0, 1fr) clamp(280px, 32vw, 332px);
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="true"]
+  .beam-console-inspector {
+  display: block;
+  grid-column: 2;
+  grid-row: 1;
+  min-height: 0;
+  border-top: 0;
+  border-left: 1px solid var(--bc-border);
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-exit {
+  position: absolute;
+  z-index: 30;
+  top: 12px;
+  right: 12px;
+  display: grid;
+  background: color-mix(in srgb, var(--bc-surface), transparent 4%);
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="true"]
+  .beam-console-focus-exit {
+  right: calc(clamp(280px, 32vw, 332px) + 12px);
+}
+
+@media (max-width: 760px) {
+  :root[data-beam-console-focus="true"] .beam-console-frame {
+    min-height: 100dvh;
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-main,
+  :root[data-beam-console-focus="true"] .beam-console-tab-main {
+    height: 100dvh;
+    min-height: 0;
+    flex: 1 1 auto;
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-main:not(.beam-console-tab-main) {
+    grid-template-rows: minmax(0, 64dvh) minmax(0, 36dvh);
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-graph-stage {
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-graph {
+    min-height: 0;
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"] {
+    display: flex;
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-inspector {
+    position: fixed;
+    display: block;
+    border-left: 1px solid var(--bc-border);
+    transform: translateX(105%);
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-inspector.is-mobile-open {
+    transform: translateX(0);
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-focus-exit {
+    right: 12px;
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-focus-inspector {
+    position: absolute;
+    z-index: 30;
+    top: 12px;
+    right: 56px;
+    display: grid;
+    background: color-mix(in srgb, var(--bc-surface), transparent 4%);
+    box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
+  }
+}

--- a/assets/js/imports.mjs
+++ b/assets/js/imports.mjs
@@ -5,13 +5,16 @@ import {
   chartAriaLabel,
   chartDomain,
   chartHeadline,
+  focusShortcutAction,
   formatChartValue,
   graphUpdateMode,
   graphOmissionLabel,
   newNodePlacements,
   readStoredBranchStates,
+  readStoredBoolean,
   readStoredTheme,
   writeStoredBranchStates,
+  writeStoredBoolean,
   writeStoredTheme,
   revisionDecision
 } from "../support/__SUPPORT_DIGEST__";

--- a/assets/js/panel_hook.mjs
+++ b/assets/js/panel_hook.mjs
@@ -3,6 +3,9 @@ const BeamConsolePanels = {
     this.media = window.matchMedia("(max-width: 760px)");
     this.activePanel = null;
     this.returnFocus = null;
+    this.focusStorageKey = this.el.dataset.beamConsoleFocusKey;
+    this.focusActive = this.readFocusPreference();
+    this.focusReturn = null;
     this.togglePanel = event => {
       const toggle = event.target.closest("[data-beam-console-panel-toggle]");
       if (!toggle || !this.media.matches) return;
@@ -20,31 +23,111 @@ const BeamConsolePanels = {
       if (!event.target.closest("[data-beam-console-panel-dismiss]")) return;
       this.closePanels();
     };
+    this.toggleFocus = event => {
+      const toggle = event.target.closest("[data-beam-console-focus-toggle]");
+      if (!toggle) return;
+
+      this.focusReturn = this.el.querySelector("#beam-console-focus-mode");
+      this.setFocusMode(!this.focusActive, true, true);
+    };
     this.keydown = event => {
       if (event.key === "Escape" && this.activePanel) {
+        event.preventDefault();
         this.closePanels();
       } else if (event.key === "Tab" && this.activePanel) {
         this.containFocus(event);
+      } else {
+        const action = focusShortcutAction(event, this.focusActive);
+        if (!action) return;
+
+        event.preventDefault();
+        this.focusReturn = this.el.querySelector("#beam-console-focus-mode");
+        this.setFocusMode(action === "toggle" ? !this.focusActive : false, true, true);
       }
     };
     this.breakpointChanged = () => {
       if (!this.media.matches) this.activePanel = null;
       this.syncPanels(false);
     };
+    this.storageChanged = event => {
+      if (event.key !== this.focusStorageKey) return;
+      const active = this.readFocusPreference();
+      this.setFocusMode(active, false, this.focusTransitionHidesActiveControl(active), true);
+    };
     this.el.addEventListener("click", this.togglePanel);
     this.el.addEventListener("click", this.dismissPanel);
+    this.el.addEventListener("click", this.toggleFocus);
     window.addEventListener("keydown", this.keydown);
+    window.addEventListener("storage", this.storageChanged);
     this.media.addEventListener("change", this.breakpointChanged);
+    this.setFocusMode(this.focusActive, false, false);
     this.syncPanels(false);
   },
   updated() {
+    this.syncFocusMode(false);
     this.syncPanels(false);
   },
   destroyed() {
     this.el.removeEventListener("click", this.togglePanel);
     this.el.removeEventListener("click", this.dismissPanel);
+    this.el.removeEventListener("click", this.toggleFocus);
     window.removeEventListener("keydown", this.keydown);
+    window.removeEventListener("storage", this.storageChanged);
     this.media.removeEventListener("change", this.breakpointChanged);
+  },
+  setFocusMode(active, persist, moveFocus, announce = persist) {
+    this.focusActive = Boolean(active);
+    document.documentElement.dataset.beamConsoleFocus = String(this.focusActive);
+
+    if (persist) this.writeFocusPreference(this.focusActive);
+    if (this.focusActive && this.activePanel) this.closePanels();
+    this.syncFocusMode(moveFocus, announce);
+    this.scheduleWorkspaceResize();
+  },
+  syncFocusMode(moveFocus, announce = false) {
+    this.el.querySelectorAll("[data-beam-console-focus-toggle]").forEach(toggle => {
+      toggle.setAttribute("aria-pressed", String(this.focusActive));
+    });
+
+    const announcement = this.el.querySelector("#beam-console-focus-announcement");
+    if (announcement && announce) {
+      announcement.textContent = this.focusActive ? "Focus mode enabled" : "Focus mode disabled";
+    }
+
+    if (!moveFocus) return;
+
+    const target = this.focusActive
+      ? this.el.querySelector("#beam-console-focus-exit")
+      : this.focusReturn || this.el.querySelector("#beam-console-focus-mode");
+    target?.focus();
+  },
+  focusTransitionHidesActiveControl(active) {
+    const current = document.activeElement;
+    if (!current || !this.el.contains(current)) return false;
+
+    if (active && this.activePanel) return true;
+
+    if (!active) {
+      return Boolean(current.closest(".beam-console-focus-exit, .beam-console-focus-inspector"));
+    }
+
+    const selected = this.el.dataset.beamConsoleHasSelection === "true";
+    const hiddenChrome = current.closest(
+      ".beam-console-header, .beam-console-sidebar, " +
+      ".beam-console-runtime-summary, .beam-console-recorder-summary"
+    );
+    const hiddenInspector = !selected && current.closest(".beam-console-inspector");
+    return Boolean(hiddenChrome || hiddenInspector);
+  },
+  scheduleWorkspaceResize() {
+    const schedule = window.requestAnimationFrame || (callback => callback());
+    schedule(() => window.dispatchEvent(new Event("resize")));
+  },
+  readFocusPreference() {
+    return readStoredBoolean(window, this.focusStorageKey);
+  },
+  writeFocusPreference(active) {
+    writeStoredBoolean(window, this.focusStorageKey, active);
   },
   closePanels() {
     const activeToggle = this.returnFocus || this.el.querySelector(

--- a/assets/js/support.mjs
+++ b/assets/js/support.mjs
@@ -18,6 +18,39 @@ export const writeStoredTheme = (storageOwner, key, theme) => {
   }
 };
 
+export const readStoredBoolean = (storageOwner, key) => {
+  try {
+    return storageOwner.localStorage.getItem(key) === "true";
+  } catch (_error) {
+    return false;
+  }
+};
+
+export const writeStoredBoolean = (storageOwner, key, value) => {
+  try {
+    const storage = storageOwner.localStorage;
+    if (value) storage.setItem(key, "true");
+    else storage.removeItem(key);
+  } catch (_error) {
+    // Browser storage can be unavailable in restricted embedding contexts.
+  }
+};
+
+export const focusShortcutAction = (event, focusActive) => {
+  const interactive = event.target?.closest?.(
+    "a[href], button, input, textarea, select, [contenteditable='true'], [role='button']"
+  );
+
+  if (event.isComposing || event.repeat || event.altKey || event.ctrlKey || event.metaKey) {
+    return null;
+  }
+
+  if (event.key === "Escape" && focusActive) return "exit";
+  if (interactive) return null;
+  if (event.key?.toLowerCase() === "f") return "toggle";
+  return null;
+};
+
 export const readStoredBranchStates = (storageOwner, key) => {
   try {
     const storage = storageOwner.localStorage;

--- a/assets/js/theme_bootstrap.js
+++ b/assets/js/theme_bootstrap.js
@@ -12,4 +12,14 @@
   const effective = theme === "system" ? (query.matches ? "dark" : "light") : theme;
   document.documentElement.dataset.theme = effective;
   document.documentElement.dataset.themeSource = theme === "system" ? "system" : "user";
+
+  let focus = false;
+  try {
+    const prefix = document.currentScript?.dataset.consolePrefix || window.location.pathname;
+    const key = `beam-console:focus:${prefix}`;
+    focus = window.localStorage.getItem(key) === "true";
+  } catch (_error) {
+    // Focus mode remains off when storage is restricted.
+  }
+  document.documentElement.dataset.beamConsoleFocus = String(focus);
 })();

--- a/assets/test/client-contracts.test.mjs
+++ b/assets/test/client-contracts.test.mjs
@@ -9,13 +9,16 @@ import {
   chartAriaLabel,
   chartDomain,
   chartHeadline,
+  focusShortcutAction,
   formatChartValue,
   graphUpdateMode,
   graphOmissionLabel,
   newNodePlacements,
   readStoredBranchStates,
+  readStoredBoolean,
   readStoredTheme,
   writeStoredBranchStates,
+  writeStoredBoolean,
   writeStoredTheme,
   revisionDecision
 } from "../js/support.mjs";
@@ -45,6 +48,44 @@ test("theme preference follows the Phoenix storage protocol", () => {
   assert.equal(readStoredTheme(storageOwner, "phx:theme", themes), null);
 });
 
+test("focus preference persists as a strict mount-scoped boolean", () => {
+  const localStorage = storage({});
+  const storageOwner = { localStorage };
+  const key = "beam-console:focus:/admin/beam";
+
+  assert.equal(readStoredBoolean(storageOwner, key), false);
+
+  writeStoredBoolean(storageOwner, key, true);
+  assert.equal(readStoredBoolean(storageOwner, key), true);
+
+  writeStoredBoolean(storageOwner, key, false);
+  assert.equal(readStoredBoolean(storageOwner, key), false);
+
+  localStorage.setItem(key, "unexpected");
+  assert.equal(readStoredBoolean(storageOwner, key), false);
+});
+
+test("focus shortcuts avoid interactive controls and modified keystrokes", () => {
+  const plainTarget = { closest: () => null };
+  const editableTarget = { closest: selector => selector.includes("input") ? {} : null };
+
+  assert.equal(focusShortcutAction({ key: "f", target: plainTarget }, false), "toggle");
+  assert.equal(focusShortcutAction({ key: "F", target: plainTarget }, true), "toggle");
+  assert.equal(focusShortcutAction({ key: "Escape", target: plainTarget }, true), "exit");
+  assert.equal(focusShortcutAction({ key: "Escape", target: editableTarget }, true), "exit");
+  assert.equal(focusShortcutAction({ key: "Escape", target: plainTarget }, false), null);
+  assert.equal(focusShortcutAction({ key: "f", target: editableTarget }, false), null);
+  assert.equal(
+    focusShortcutAction({ key: "f", target: editableTarget, isComposing: true }, false),
+    null
+  );
+  assert.equal(
+    focusShortcutAction({ key: "f", target: plainTarget, metaKey: true }, false),
+    null
+  );
+  assert.equal(focusShortcutAction({ key: "f", target: plainTarget, repeat: true }, false), null);
+});
+
 test("restricted storage getters cannot abort client startup", () => {
   const storageOwner = {
     get localStorage() {
@@ -53,8 +94,10 @@ test("restricted storage getters cannot abort client startup", () => {
   };
 
   assert.equal(readStoredTheme(storageOwner, "phx:theme", new Set(["dark"])), null);
+  assert.equal(readStoredBoolean(storageOwner, "beam-console:focus:/beam"), false);
   assert.deepEqual(readStoredBranchStates(storageOwner, "tree"), []);
   assert.doesNotThrow(() => writeStoredTheme(storageOwner, "phx:theme", "dark"));
+  assert.doesNotThrow(() => writeStoredBoolean(storageOwner, "beam-console:focus:/beam", true));
   assert.doesNotThrow(() => writeStoredBranchStates(storageOwner, "tree", new Map()));
 });
 
@@ -292,6 +335,70 @@ test("mobile panels restore focus when dismissed", () => {
   assert.equal(focused, true);
 });
 
+test("focus mode updates browser state without touching runtime controls", () => {
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  const localStorage = storage({});
+  let synced = false;
+  let resized = false;
+
+  globalThis.document = { documentElement: { dataset: {} } };
+  globalThis.window = { localStorage };
+
+  try {
+    const hook = {
+      ...BeamConsolePanels,
+      activePanel: null,
+      focusActive: false,
+      focusStorageKey: "beam-console:focus:/beam",
+      writeFocusPreference: active => {
+        writeStoredBoolean(window, "beam-console:focus:/beam", active);
+      },
+      syncFocusMode: () => { synced = true; },
+      scheduleWorkspaceResize: () => { resized = true; }
+    };
+
+    hook.setFocusMode(true, true, false);
+
+    assert.equal(hook.focusActive, true);
+    assert.equal(document.documentElement.dataset.beamConsoleFocus, "true");
+    assert.equal(localStorage.getItem(hook.focusStorageKey), "true");
+    assert.equal(synced, true);
+    assert.equal(resized, true);
+  } finally {
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+  }
+});
+
+test("storage-driven focus changes recover focus only from hidden chrome", () => {
+  const headerControl = { closest: selector => selector.includes("beam-console-header") ? {} : null };
+  const workspaceControl = { closest: () => null };
+  const previousDocument = globalThis.document;
+
+  try {
+    const hook = {
+      ...BeamConsolePanels,
+      el: {
+        contains: element => [headerControl, workspaceControl].includes(element),
+        dataset: { beamConsoleHasSelection: "false" }
+      }
+    };
+
+    globalThis.document = { activeElement: headerControl };
+    assert.equal(hook.focusTransitionHidesActiveControl(true), true);
+
+    globalThis.document = { activeElement: workspaceControl };
+    assert.equal(hook.focusTransitionHidesActiveControl(true), false);
+
+    hook.activePanel = "inspector";
+    hook.el.dataset.beamConsoleHasSelection = "true";
+    assert.equal(hook.focusTransitionHidesActiveControl(true), true);
+  } finally {
+    globalThis.document = previousDocument;
+  }
+});
+
 test("mobile panels wrap keyboard focus inside the active drawer", () => {
   let firstFocused = false;
   const first = { closest: () => null, focus: () => { firstFocused = true; } };
@@ -366,4 +473,47 @@ test("header navigation keeps a fixed center column across tabs", async () => {
     /@media \(max-width: 1180px\)[\s\S]*?\.beam-console-header\s*\{[\s\S]*?grid-template-columns:\s*auto minmax\(0, 1fr\)[\s\S]*?grid-template-rows:\s*auto auto/
   );
   assert.match(stylesheet, /\.beam-console-search-form\.is-placeholder\s*\{[\s\S]*?visibility:\s*hidden/);
+});
+
+test("focus mode removes chrome without changing the active workspace", async () => {
+  const stylesheet = await readFile(
+    new URL("../../priv/static/beam_console.css", import.meta.url),
+    "utf8"
+  );
+  const bootstrap = await readFile(
+    new URL("../../priv/static/beam_console_theme.js", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(bootstrap, /beam-console:focus:/);
+  assert.match(bootstrap, /document\.currentScript/);
+  assert.match(bootstrap, /dataset\.consolePrefix/);
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-header[\s\S]*?display:\s*none/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?data-beam-console-has-selection="false"[\s\S]*?\.beam-console-inspector[\s\S]*?display:\s*none/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-focus-exit[\s\S]*?display:\s*grid/
+  );
+  assert.match(
+    stylesheet,
+    /@media \(max-width: 760px\)[\s\S]*?data-beam-console-focus="true"[\s\S]*?\.beam-console-focus-inspector[\s\S]*?display:\s*grid/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) clamp\(280px, 32vw, 332px\)/
+  );
+  assert.match(
+    stylesheet,
+    /@media \(max-width: 760px\)[\s\S]*?\.beam-console-main:not\(\.beam-console-tab-main\)[\s\S]*?grid-template-rows:\s*minmax\(0, 64dvh\) minmax\(0, 36dvh\)/
+  );
+  assert.match(
+    stylesheet,
+    /@media \(max-width: 760px\)[\s\S]*?data-beam-console-focus="true"[\s\S]*?\.beam-console-graph\s*\{[\s\S]*?min-height:\s*0/
+  );
 });

--- a/lib/beam_console_web/assets.ex
+++ b/lib/beam_console_web/assets.ex
@@ -105,7 +105,7 @@ if Code.ensure_loaded?(Phoenix.Controller) and Code.ensure_loaded?(Phoenix.LiveV
       @support_digest
     end
 
-    @doc "Returns the digest for BeamConsole's first-paint theme bootstrap."
+    @doc "Returns the digest for BeamConsole's first-paint display bootstrap."
     @spec theme_digest() :: String.t()
     def theme_digest do
       @theme_digest
@@ -171,7 +171,7 @@ if Code.ensure_loaded?(Phoenix.Controller) and Code.ensure_loaded?(Phoenix.LiveV
       send_resp(conn, 404, "Not Found")
     end
 
-    @doc "Serves BeamConsole's first-paint theme bootstrap when its digest matches."
+    @doc "Serves BeamConsole's first-paint display bootstrap when its digest matches."
     @spec theme(Plug.Conn.t(), map()) :: Plug.Conn.t()
     def theme(%{params: %{"digest" => @theme_digest}} = conn, _params) do
       send_asset(conn, "text/javascript", @theme)

--- a/lib/beam_console_web/components/shell_components.ex
+++ b/lib/beam_console_web/components/shell_components.ex
@@ -1,6 +1,6 @@
 if Code.ensure_loaded?(Phoenix.Component) do
   defmodule BeamConsoleWeb.Components.ShellComponents do
-    @moduledoc "Renders the BeamConsole header, navigation, and browser-owned theme controls."
+    @moduledoc "Renders the BeamConsole header, navigation, and browser-owned display controls."
 
     use Phoenix.Component
 
@@ -14,7 +14,7 @@ if Code.ensure_loaded?(Phoenix.Component) do
     attr(:recording_control_available?, :boolean, required: true)
     attr(:refresh_pending?, :boolean, default: false)
 
-    @doc "Renders the dashboard header with tabs, recording controls, refresh, and theme selection."
+    @doc "Renders the dashboard header with tabs, recording, refresh, focus, and theme controls."
     @spec header(map()) :: Phoenix.LiveView.Rendered.t()
     def header(assigns) do
       ~H"""
@@ -146,6 +146,21 @@ if Code.ensure_loaded?(Phoenix.Component) do
               aria-hidden="true"
             >
               <path d="m8 5 11 7-11 7V5Z" />
+            </svg>
+          </button>
+
+          <button
+            id="beam-console-focus-mode"
+            type="button"
+            class="beam-console-icon-button"
+            data-beam-console-focus-toggle
+            aria-label="Enter focus mode"
+            aria-keyshortcuts="F"
+            aria-pressed="false"
+            data-tooltip="Focus mode (F)"
+          >
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M9 4H4v5M15 4h5v5M20 15v5h-5M4 15v5h5" />
             </svg>
           </button>
 

--- a/lib/beam_console_web/console_live.ex
+++ b/lib/beam_console_web/console_live.ex
@@ -255,7 +255,13 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     def render(assigns) do
       ~H"""
       <div id="beam-console" class="beam-console-shell" phx-hook="BeamConsoleTheme">
-        <div id="beam-console-panels" class="beam-console-frame" phx-hook="BeamConsolePanels">
+        <div
+          id="beam-console-panels"
+          class="beam-console-frame"
+          phx-hook="BeamConsolePanels"
+          data-beam-console-focus-key={"beam-console:focus:#{@prefix}"}
+          data-beam-console-has-selection={if(is_nil(@selected), do: "false", else: "true")}
+        >
           <.header
             page_title={@page_title}
             status_label={@status_label}
@@ -267,6 +273,43 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             recording_control_available?={@recording_control_available?}
             refresh_pending?={@graph_refresh_pending?}
           />
+
+          <span
+            id="beam-console-focus-announcement"
+            class="beam-console-visually-hidden"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          ></span>
+          <button
+            id="beam-console-focus-inspector"
+            type="button"
+            class="beam-console-icon-button beam-console-focus-inspector"
+            data-beam-console-panel-toggle="inspector"
+            aria-controls="beam-console-inspector-panel"
+            aria-expanded="false"
+            aria-label="Open inspector"
+            data-tooltip="Inspector"
+          >
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle cx="11" cy="11" r="6" />
+              <path d="m16 16 4 4M11 8v6M8 11h6" />
+            </svg>
+          </button>
+          <button
+            id="beam-console-focus-exit"
+            type="button"
+            class="beam-console-icon-button beam-console-focus-exit"
+            data-beam-console-focus-toggle
+            aria-label="Exit focus mode"
+            aria-keyshortcuts="Escape"
+            aria-pressed="false"
+            data-tooltip="Exit focus mode (Esc)"
+          >
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M4 9h5V4M20 9h-5V4M20 15h-5v5M4 15h5v5" />
+            </svg>
+          </button>
 
           <.runtime_tree
             nodes={@nodes}

--- a/lib/beam_console_web/layouts.ex
+++ b/lib/beam_console_web/layouts.ex
@@ -30,7 +30,7 @@ if Code.ensure_loaded?(Phoenix.Component) do
           <.live_title default="Process Map" prefix="BeamConsole · ">
             {@page_title}
           </.live_title>
-          <script src={@theme_path}>
+          <script src={@theme_path} data-console-prefix={@prefix}>
           </script>
           <link rel="stylesheet" href={@css_path} />
           <script

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BeamConsole.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ccarvalho-eng/beam_console"
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [

--- a/priv/static/beam_console.css
+++ b/priv/static/beam_console.css
@@ -407,7 +407,9 @@
 }
 
 .beam-console-panel-toggle,
-.beam-console-panel-backdrop {
+.beam-console-panel-backdrop,
+.beam-console-focus-inspector,
+.beam-console-focus-exit {
   display: none;
 }
 .beam-console-visually-hidden {
@@ -1641,5 +1643,136 @@
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+}
+
+:root[data-beam-console-focus="true"] .beam-console-shell {
+  height: 100dvh;
+  padding: 0;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-frame {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  height: 100dvh;
+  min-height: 640px;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-header,
+:root[data-beam-console-focus="true"] .beam-console-sidebar,
+:root[data-beam-console-focus="true"] .beam-console-runtime-summary,
+:root[data-beam-console-focus="true"] .beam-console-recorder-summary {
+  display: none;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-main {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="false"]
+  .beam-console-inspector {
+  display: none;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="true"] {
+  grid-template-columns: minmax(0, 1fr) clamp(280px, 32vw, 332px);
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="true"]
+  .beam-console-inspector {
+  display: block;
+  grid-column: 2;
+  grid-row: 1;
+  min-height: 0;
+  border-top: 0;
+  border-left: 1px solid var(--bc-border);
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-exit {
+  position: absolute;
+  z-index: 30;
+  top: 12px;
+  right: 12px;
+  display: grid;
+  background: color-mix(in srgb, var(--bc-surface), transparent 4%);
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame[data-beam-console-has-selection="true"]
+  .beam-console-focus-exit {
+  right: calc(clamp(280px, 32vw, 332px) + 12px);
+}
+
+@media (max-width: 760px) {
+  :root[data-beam-console-focus="true"] .beam-console-frame {
+    min-height: 100dvh;
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-main,
+  :root[data-beam-console-focus="true"] .beam-console-tab-main {
+    height: 100dvh;
+    min-height: 0;
+    flex: 1 1 auto;
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-main:not(.beam-console-tab-main) {
+    grid-template-rows: minmax(0, 64dvh) minmax(0, 36dvh);
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-graph-stage {
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  :root[data-beam-console-focus="true"] .beam-console-graph {
+    min-height: 0;
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"] {
+    display: flex;
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-inspector {
+    position: fixed;
+    display: block;
+    border-left: 1px solid var(--bc-border);
+    transform: translateX(105%);
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-inspector.is-mobile-open {
+    transform: translateX(0);
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-focus-exit {
+    right: 12px;
+  }
+
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"]
+    .beam-console-focus-inspector {
+    position: absolute;
+    z-index: 30;
+    top: 12px;
+    right: 56px;
+    display: grid;
+    background: color-mix(in srgb, var(--bc-surface), transparent 4%);
+    box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
   }
 }

--- a/priv/static/beam_console.mjs
+++ b/priv/static/beam_console.mjs
@@ -6,13 +6,16 @@ import {
   chartAriaLabel,
   chartDomain,
   chartHeadline,
+  focusShortcutAction,
   formatChartValue,
   graphUpdateMode,
   graphOmissionLabel,
   newNodePlacements,
   readStoredBranchStates,
+  readStoredBoolean,
   readStoredTheme,
   writeStoredBranchStates,
+  writeStoredBoolean,
   writeStoredTheme,
   revisionDecision
 } from "../support/__SUPPORT_DIGEST__";
@@ -173,6 +176,9 @@ const BeamConsolePanels = {
     this.media = window.matchMedia("(max-width: 760px)");
     this.activePanel = null;
     this.returnFocus = null;
+    this.focusStorageKey = this.el.dataset.beamConsoleFocusKey;
+    this.focusActive = this.readFocusPreference();
+    this.focusReturn = null;
     this.togglePanel = event => {
       const toggle = event.target.closest("[data-beam-console-panel-toggle]");
       if (!toggle || !this.media.matches) return;
@@ -190,31 +196,111 @@ const BeamConsolePanels = {
       if (!event.target.closest("[data-beam-console-panel-dismiss]")) return;
       this.closePanels();
     };
+    this.toggleFocus = event => {
+      const toggle = event.target.closest("[data-beam-console-focus-toggle]");
+      if (!toggle) return;
+
+      this.focusReturn = this.el.querySelector("#beam-console-focus-mode");
+      this.setFocusMode(!this.focusActive, true, true);
+    };
     this.keydown = event => {
       if (event.key === "Escape" && this.activePanel) {
+        event.preventDefault();
         this.closePanels();
       } else if (event.key === "Tab" && this.activePanel) {
         this.containFocus(event);
+      } else {
+        const action = focusShortcutAction(event, this.focusActive);
+        if (!action) return;
+
+        event.preventDefault();
+        this.focusReturn = this.el.querySelector("#beam-console-focus-mode");
+        this.setFocusMode(action === "toggle" ? !this.focusActive : false, true, true);
       }
     };
     this.breakpointChanged = () => {
       if (!this.media.matches) this.activePanel = null;
       this.syncPanels(false);
     };
+    this.storageChanged = event => {
+      if (event.key !== this.focusStorageKey) return;
+      const active = this.readFocusPreference();
+      this.setFocusMode(active, false, this.focusTransitionHidesActiveControl(active), true);
+    };
     this.el.addEventListener("click", this.togglePanel);
     this.el.addEventListener("click", this.dismissPanel);
+    this.el.addEventListener("click", this.toggleFocus);
     window.addEventListener("keydown", this.keydown);
+    window.addEventListener("storage", this.storageChanged);
     this.media.addEventListener("change", this.breakpointChanged);
+    this.setFocusMode(this.focusActive, false, false);
     this.syncPanels(false);
   },
   updated() {
+    this.syncFocusMode(false);
     this.syncPanels(false);
   },
   destroyed() {
     this.el.removeEventListener("click", this.togglePanel);
     this.el.removeEventListener("click", this.dismissPanel);
+    this.el.removeEventListener("click", this.toggleFocus);
     window.removeEventListener("keydown", this.keydown);
+    window.removeEventListener("storage", this.storageChanged);
     this.media.removeEventListener("change", this.breakpointChanged);
+  },
+  setFocusMode(active, persist, moveFocus, announce = persist) {
+    this.focusActive = Boolean(active);
+    document.documentElement.dataset.beamConsoleFocus = String(this.focusActive);
+
+    if (persist) this.writeFocusPreference(this.focusActive);
+    if (this.focusActive && this.activePanel) this.closePanels();
+    this.syncFocusMode(moveFocus, announce);
+    this.scheduleWorkspaceResize();
+  },
+  syncFocusMode(moveFocus, announce = false) {
+    this.el.querySelectorAll("[data-beam-console-focus-toggle]").forEach(toggle => {
+      toggle.setAttribute("aria-pressed", String(this.focusActive));
+    });
+
+    const announcement = this.el.querySelector("#beam-console-focus-announcement");
+    if (announcement && announce) {
+      announcement.textContent = this.focusActive ? "Focus mode enabled" : "Focus mode disabled";
+    }
+
+    if (!moveFocus) return;
+
+    const target = this.focusActive
+      ? this.el.querySelector("#beam-console-focus-exit")
+      : this.focusReturn || this.el.querySelector("#beam-console-focus-mode");
+    target?.focus();
+  },
+  focusTransitionHidesActiveControl(active) {
+    const current = document.activeElement;
+    if (!current || !this.el.contains(current)) return false;
+
+    if (active && this.activePanel) return true;
+
+    if (!active) {
+      return Boolean(current.closest(".beam-console-focus-exit, .beam-console-focus-inspector"));
+    }
+
+    const selected = this.el.dataset.beamConsoleHasSelection === "true";
+    const hiddenChrome = current.closest(
+      ".beam-console-header, .beam-console-sidebar, " +
+      ".beam-console-runtime-summary, .beam-console-recorder-summary"
+    );
+    const hiddenInspector = !selected && current.closest(".beam-console-inspector");
+    return Boolean(hiddenChrome || hiddenInspector);
+  },
+  scheduleWorkspaceResize() {
+    const schedule = window.requestAnimationFrame || (callback => callback());
+    schedule(() => window.dispatchEvent(new Event("resize")));
+  },
+  readFocusPreference() {
+    return readStoredBoolean(window, this.focusStorageKey);
+  },
+  writeFocusPreference(active) {
+    writeStoredBoolean(window, this.focusStorageKey, active);
   },
   closePanels() {
     const activeToggle = this.returnFocus || this.el.querySelector(

--- a/priv/static/beam_console_support.mjs
+++ b/priv/static/beam_console_support.mjs
@@ -19,6 +19,39 @@ export const writeStoredTheme = (storageOwner, key, theme) => {
   }
 };
 
+export const readStoredBoolean = (storageOwner, key) => {
+  try {
+    return storageOwner.localStorage.getItem(key) === "true";
+  } catch (_error) {
+    return false;
+  }
+};
+
+export const writeStoredBoolean = (storageOwner, key, value) => {
+  try {
+    const storage = storageOwner.localStorage;
+    if (value) storage.setItem(key, "true");
+    else storage.removeItem(key);
+  } catch (_error) {
+    // Browser storage can be unavailable in restricted embedding contexts.
+  }
+};
+
+export const focusShortcutAction = (event, focusActive) => {
+  const interactive = event.target?.closest?.(
+    "a[href], button, input, textarea, select, [contenteditable='true'], [role='button']"
+  );
+
+  if (event.isComposing || event.repeat || event.altKey || event.ctrlKey || event.metaKey) {
+    return null;
+  }
+
+  if (event.key === "Escape" && focusActive) return "exit";
+  if (interactive) return null;
+  if (event.key?.toLowerCase() === "f") return "toggle";
+  return null;
+};
+
 export const readStoredBranchStates = (storageOwner, key) => {
   try {
     const storage = storageOwner.localStorage;

--- a/priv/static/beam_console_theme.js
+++ b/priv/static/beam_console_theme.js
@@ -13,4 +13,14 @@
   const effective = theme === "system" ? (query.matches ? "dark" : "light") : theme;
   document.documentElement.dataset.theme = effective;
   document.documentElement.dataset.themeSource = theme === "system" ? "system" : "user";
+
+  let focus = false;
+  try {
+    const prefix = document.currentScript?.dataset.consolePrefix || window.location.pathname;
+    const key = `beam-console:focus:${prefix}`;
+    focus = window.localStorage.getItem(key) === "true";
+  } catch (_error) {
+    // Focus mode remains off when storage is restricted.
+  }
+  document.documentElement.dataset.beamConsoleFocus = String(focus);
 })();

--- a/test/beam_console_web/console_live_test.exs
+++ b/test/beam_console_web/console_live_test.exs
@@ -49,11 +49,27 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
     assert has_element?(view, "#beam-console-tab-process_map[aria-current='page']")
     assert has_element?(view, "#beam-console-tab-lifecycle")
     assert has_element?(view, "#beam-console-recorder-control")
+    assert has_element?(view, "#beam-console-focus-mode[aria-pressed='false'] svg")
     assert has_element?(view, "#beam-console-refresh[aria-label='Refresh runtime sample'] svg")
 
     assert has_element?(
              view,
-             "#beam-console-refresh + #beam-console-theme-switcher button[data-beam-console-theme='system']"
+             "#beam-console-focus-mode + #beam-console-refresh + #beam-console-theme-switcher button[data-beam-console-theme='system']"
+           )
+
+    assert has_element?(
+             view,
+             "#beam-console-focus-exit[data-beam-console-focus-toggle][aria-pressed='false']"
+           )
+
+    assert has_element?(
+             view,
+             "#beam-console-focus-inspector[data-beam-console-panel-toggle='inspector'][aria-expanded='false']"
+           )
+
+    assert has_element?(
+             view,
+             "#beam-console-panels[data-beam-console-focus-key='beam-console:focus:/beam'][data-beam-console-has-selection='false']"
            )
 
     assert has_element?(
@@ -78,6 +94,21 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
     refute render(view) =~ "Runtime sampling is live · sample"
     assert has_element?(view, "button[phx-value-edges='supervision'][aria-pressed='true']")
     assert has_element?(view, "button[phx-value-edges='relationships'][aria-pressed='false']")
+  end
+
+  test "keeps the focus preference scope stable across patched dashboard tabs" do
+    {:ok, view, _html} = live(build_conn(), "/beam")
+
+    view
+    |> element("#beam-console-tab-activity")
+    |> render_click()
+
+    assert_patch(view, "/beam/activity")
+
+    assert has_element?(
+             view,
+             "#beam-console-panels[data-beam-console-focus-key='beam-console:focus:/beam']"
+           )
   end
 
   test "updates process-map labels with the selected connection mode" do
@@ -111,6 +142,7 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
       live(build_conn(), "/beam?" <> URI.encode_query(%{"entity" => process.id}))
 
     assert has_element?(view, "#processes-#{process.id}[aria-pressed='true']")
+    assert has_element?(view, "#beam-console-panels[data-beam-console-has-selection='true']")
     send(view.pid, {:beam_console_snapshot, snapshot.sequence})
     assert has_element?(view, "#processes-#{process.id}[aria-pressed='true']")
     assert has_element?(view, "#beam-console-tab-process_map[aria-current='page']")


### PR DESCRIPTION
## Summary

- add a distraction-free Focus mode that hides navigation, runtime hierarchy, recording controls, and summary cards while preserving the active workspace
- restore the mount-scoped preference before first paint and keep it synchronized across tabs and LiveView route patches
- provide accessible enter, exit, and mobile inspector controls with guarded F and Escape shortcuts
- resize graphs and charts after layout transitions and handle short landscape, mobile, tablet, and selected-inspector layouts
- prepare BeamConsole 0.5.1 release metadata and documentation

## Runtime behavior

Focus mode is browser-owned presentation state. It does not send a LiveView event, change collector demand, pause sampling, or change lifecycle recording. Restricted browser storage degrades safely to Focus mode off.