### PR TITLE
fix(console): refine focus workspace controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.5.2 - 2026-08-28
+
+- Move Focus controls into a dedicated full-viewport bar so they never cover workspace headings.
+- Make the runtime hierarchy available as an accessible Focus drawer at every viewport width.
+- Place the Focus control immediately before the theme switcher in the standard header.
+
 ## 0.5.1 - 2026-08-28
 
 - Add a mount-scoped Focus mode that removes surrounding chrome without changing sampling or recording.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add BeamConsole to a Phoenix application:
 ```elixir
 def deps do
   [
-    {:beam_console, "~> 0.5.1"}
+    {:beam_console, "~> 0.5.2"}
   ]
 end
 ```
@@ -69,7 +69,7 @@ Call `BeamConsole.unsubscribe/0` when a long-lived manual subscriber no longer n
 - Activity: reductions per second, mailbox growth, memory movement, and ranked process movers.
 - Runtime: BEAM memory categories, CPU/I/O run queues, input/output throughput, process, port, and atom capacity, scheduler topology, uptime, runtime inventory, collector duration, applications, ETS tables, and connected-node inventory.
 - Inspector: allowlisted process, application, and node details, including scheduling, heap, and selected garbage-collection diagnostics. Process relationships and group leaders are clickable when their target is present in the latest sample.
-- Focus mode: hide navigation, hierarchy, recording controls, and summary cards without interrupting collection or recording. Press `F` to toggle it or `Escape` to leave it; the mount-scoped preference persists locally.
+- Focus mode: use the active workspace at full viewport size with a dedicated control bar and on-demand runtime hierarchy drawer, without interrupting collection or recording. Press `F` to toggle it or `Escape` to leave it; the mount-scoped preference persists locally.
 
 Applications are grouped into host, dependencies, OTP, and tooling categories. Every tree branch can be collapsed and its state remains stable while LiveView updates.
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -407,8 +407,7 @@
 
 .beam-console-panel-toggle,
 .beam-console-panel-backdrop,
-.beam-console-focus-inspector,
-.beam-console-focus-exit {
+.beam-console-focus-bar {
   display: none;
 }
 .beam-console-visually-hidden {

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -202,7 +202,7 @@
     cursor: default;
   }
 
-  .beam-console-frame.has-mobile-panel .beam-console-panel-backdrop {
+  .beam-console-frame.has-overlay-panel .beam-console-panel-backdrop {
     display: block;
   }
 
@@ -257,32 +257,107 @@
 
 :root[data-beam-console-focus="true"] .beam-console-shell {
   height: 100dvh;
+  min-height: 0;
   padding: 0;
 }
 
 :root[data-beam-console-focus="true"] .beam-console-frame {
   position: relative;
+  display: grid;
   width: 100%;
   max-width: none;
   height: 100dvh;
-  min-height: 640px;
+  min-height: 0;
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, 1fr);
   border: 0;
   border-radius: 0;
   box-shadow: none;
 }
 
 :root[data-beam-console-focus="true"] .beam-console-header,
-:root[data-beam-console-focus="true"] .beam-console-sidebar,
 :root[data-beam-console-focus="true"] .beam-console-runtime-summary,
 :root[data-beam-console-focus="true"] .beam-console-recorder-summary {
   display: none;
 }
 
+:root[data-beam-console-focus="true"] .beam-console-focus-bar {
+  z-index: 30;
+  display: flex;
+  grid-column: 1 / -1;
+  grid-row: 1;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px 0 16px;
+  border-bottom: 1px solid var(--bc-border);
+  background: color-mix(in srgb, var(--bc-surface), var(--bc-surface-muted) 28%);
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-label {
+  color: var(--bc-muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-actions .beam-console-icon-button {
+  display: grid;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-focus-actions
+  .beam-console-focus-inspector {
+  display: none;
+}
+
 :root[data-beam-console-focus="true"] .beam-console-main {
   grid-column: 1;
-  grid-row: 1;
+  grid-row: 2;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-sidebar {
+  position: fixed;
+  z-index: 40;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  display: block;
+  width: min(88vw, 360px);
+  border-right: 1px solid var(--bc-border);
+  box-shadow: 18px 0 42px rgb(15 23 42 / 22%);
+  transform: translateX(-105%);
+  transition: transform 160ms ease;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-sidebar.is-mobile-open {
+  transform: translateX(0);
+}
+
+:root[data-beam-console-focus="true"] .beam-console-sidebar .beam-console-panel-close {
+  display: inline-flex;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-panel-backdrop {
+  position: fixed;
+  z-index: 35;
+  inset: 0;
+  border: 0;
+  background: rgb(15 23 42 / 42%);
+  cursor: default;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame.has-overlay-panel
+  .beam-console-panel-backdrop {
+  display: block;
 }
 
 :root[data-beam-console-focus="true"]
@@ -301,26 +376,10 @@
   .beam-console-inspector {
   display: block;
   grid-column: 2;
-  grid-row: 1;
+  grid-row: 2;
   min-height: 0;
   border-top: 0;
   border-left: 1px solid var(--bc-border);
-}
-
-:root[data-beam-console-focus="true"] .beam-console-focus-exit {
-  position: absolute;
-  z-index: 30;
-  top: 12px;
-  right: 12px;
-  display: grid;
-  background: color-mix(in srgb, var(--bc-surface), transparent 4%);
-  box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
-}
-
-:root[data-beam-console-focus="true"]
-  .beam-console-frame[data-beam-console-has-selection="true"]
-  .beam-console-focus-exit {
-  right: calc(clamp(280px, 32vw, 332px) + 12px);
 }
 
 @media (max-width: 760px) {
@@ -330,13 +389,18 @@
 
   :root[data-beam-console-focus="true"] .beam-console-main,
   :root[data-beam-console-focus="true"] .beam-console-tab-main {
-    height: 100dvh;
+    height: calc(100dvh - 48px);
     min-height: 0;
     flex: 1 1 auto;
   }
 
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   :root[data-beam-console-focus="true"] .beam-console-main:not(.beam-console-tab-main) {
-    grid-template-rows: minmax(0, 64dvh) minmax(0, 36dvh);
+    grid-template-rows: minmax(0, 1.8fr) minmax(0, 1fr);
   }
 
   :root[data-beam-console-focus="true"] .beam-console-graph-stage {
@@ -345,11 +409,6 @@
 
   :root[data-beam-console-focus="true"] .beam-console-graph {
     min-height: 0;
-  }
-
-  :root[data-beam-console-focus="true"]
-    .beam-console-frame[data-beam-console-has-selection="true"] {
-    display: flex;
   }
 
   :root[data-beam-console-focus="true"]
@@ -369,19 +428,7 @@
 
   :root[data-beam-console-focus="true"]
     .beam-console-frame[data-beam-console-has-selection="true"]
-    .beam-console-focus-exit {
-    right: 12px;
-  }
-
-  :root[data-beam-console-focus="true"]
-    .beam-console-frame[data-beam-console-has-selection="true"]
     .beam-console-focus-inspector {
-    position: absolute;
-    z-index: 30;
-    top: 12px;
-    right: 56px;
     display: grid;
-    background: color-mix(in srgb, var(--bc-surface), transparent 4%);
-    box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
   }
 }

--- a/assets/js/panel_hook.mjs
+++ b/assets/js/panel_hook.mjs
@@ -8,8 +8,10 @@ const BeamConsolePanels = {
     this.focusReturn = null;
     this.togglePanel = event => {
       const toggle = event.target.closest("[data-beam-console-panel-toggle]");
-      if (!toggle || !this.media.matches) return;
+      if (!toggle) return;
       const name = toggle.dataset.beamConsolePanelToggle;
+      if (!this.panelIsDrawer(name)) return;
+
       if (this.activePanel === name) {
         this.closePanels();
         return;
@@ -45,10 +47,7 @@ const BeamConsolePanels = {
         this.setFocusMode(action === "toggle" ? !this.focusActive : false, true, true);
       }
     };
-    this.breakpointChanged = () => {
-      if (!this.media.matches) this.activePanel = null;
-      this.syncPanels(false);
-    };
+    this.breakpointChanged = () => this.syncBreakpoint();
     this.storageChanged = event => {
       if (event.key !== this.focusStorageKey) return;
       const active = this.readFocusPreference();
@@ -65,6 +64,17 @@ const BeamConsolePanels = {
   },
   updated() {
     this.syncFocusMode(false);
+
+    if (
+      this.focusActive &&
+      this.activePanel === "inspector" &&
+      this.el.dataset.beamConsoleHasSelection !== "true"
+    ) {
+      this.returnFocus = this.el.querySelector("#beam-console-focus-exit");
+      this.closePanels();
+      return;
+    }
+
     this.syncPanels(false);
   },
   destroyed() {
@@ -76,12 +86,14 @@ const BeamConsolePanels = {
     this.media.removeEventListener("change", this.breakpointChanged);
   },
   setFocusMode(active, persist, moveFocus, announce = persist) {
+    const changed = this.focusActive !== Boolean(active);
     this.focusActive = Boolean(active);
     document.documentElement.dataset.beamConsoleFocus = String(this.focusActive);
 
     if (persist) this.writeFocusPreference(this.focusActive);
-    if (this.focusActive && this.activePanel) this.closePanels();
+    if (changed && this.activePanel) this.closePanels();
     this.syncFocusMode(moveFocus, announce);
+    this.syncPanels(false);
     this.scheduleWorkspaceResize();
   },
   syncFocusMode(moveFocus, announce = false) {
@@ -108,7 +120,7 @@ const BeamConsolePanels = {
     if (active && this.activePanel) return true;
 
     if (!active) {
-      return Boolean(current.closest(".beam-console-focus-exit, .beam-console-focus-inspector"));
+      return Boolean(this.activePanel || current.closest(".beam-console-focus-bar"));
     }
 
     const selected = this.el.dataset.beamConsoleHasSelection === "true";
@@ -129,10 +141,37 @@ const BeamConsolePanels = {
   writeFocusPreference(active) {
     writeStoredBoolean(window, this.focusStorageKey, active);
   },
-  closePanels() {
-    const activeToggle = this.returnFocus || this.el.querySelector(
-      `[data-beam-console-panel-toggle="${this.activePanel}"]`
+  panelIsDrawer(name) {
+    return this.media.matches || (this.focusActive && name === "runtime");
+  },
+  panelToggle(name) {
+    const focusToggle = this.focusActive
+      ? this.el.querySelector(`#beam-console-focus-${name}`)
+      : null;
+
+    return focusToggle || this.el.querySelector(
+      `[data-beam-console-panel-toggle="${name}"]`
     );
+  },
+  syncBreakpoint() {
+    const focusedPanel = document.activeElement?.closest?.("[data-beam-console-panel]");
+    const focusedName = focusedPanel?.dataset.beamConsolePanel;
+
+    if (focusedName && this.panelIsDrawer(focusedName)) {
+      this.activePanel = focusedName;
+      this.returnFocus = this.panelToggle(focusedName);
+      this.syncPanels(true);
+      return;
+    }
+
+    if (this.activePanel && !this.panelIsDrawer(this.activePanel)) {
+      this.activePanel = null;
+    }
+
+    this.syncPanels(false);
+  },
+  closePanels() {
+    const activeToggle = this.returnFocus || this.panelToggle(this.activePanel);
     this.activePanel = null;
     this.returnFocus = null;
     this.syncPanels(false);
@@ -170,18 +209,19 @@ const BeamConsolePanels = {
     }
   },
   syncPanels(focusPanel) {
-    const mobile = this.media.matches;
-    const modalOpen = mobile && Boolean(this.activePanel);
+    const overlayOpen = Boolean(this.activePanel) && this.panelIsDrawer(this.activePanel);
 
     this.el.querySelectorAll("[data-beam-console-panel]").forEach(panel => {
-      const active = mobile && panel.dataset.beamConsolePanel === this.activePanel;
+      const name = panel.dataset.beamConsolePanel;
+      const drawer = this.panelIsDrawer(name);
+      const active = overlayOpen && name === this.activePanel;
       panel.classList.toggle("is-mobile-open", active);
-      panel.inert = mobile && !active;
+      panel.inert = overlayOpen ? !active : drawer;
 
       if (panel.inert) panel.setAttribute("inert", "");
       else panel.removeAttribute("inert");
 
-      if (mobile) panel.setAttribute("aria-hidden", String(!active));
+      if (overlayOpen || drawer) panel.setAttribute("aria-hidden", String(!active));
       else panel.removeAttribute("aria-hidden");
 
       if (active) {
@@ -201,17 +241,17 @@ const BeamConsolePanels = {
       );
       if (!background) return;
 
-      child.inert = modalOpen;
+      child.inert = overlayOpen;
       if (child.inert) child.setAttribute("inert", "");
       else child.removeAttribute("inert");
     });
 
     this.el.querySelectorAll("[data-beam-console-panel-toggle]").forEach(toggle => {
-      const active = mobile && toggle.dataset.beamConsolePanelToggle === this.activePanel;
+      const active = overlayOpen && toggle.dataset.beamConsolePanelToggle === this.activePanel;
       toggle.setAttribute("aria-expanded", String(active));
     });
 
-    this.el.classList.toggle("has-mobile-panel", modalOpen);
+    this.el.classList.toggle("has-overlay-panel", overlayOpen);
   }
 };
 

--- a/assets/test/client-contracts.test.mjs
+++ b/assets/test/client-contracts.test.mjs
@@ -304,7 +304,7 @@ test("narrow layouts expose runtime and inspector as overlay panels", async () =
   );
   assert.match(
     stylesheet,
-    /\.beam-console-frame\.has-mobile-panel \.beam-console-panel-backdrop\s*\{[\s\S]*?display:\s*block/
+    /\.beam-console-frame\.has-overlay-panel \.beam-console-panel-backdrop\s*\{[\s\S]*?display:\s*block/
   );
 
   const panelHook = await readFile(
@@ -312,9 +312,20 @@ test("narrow layouts expose runtime and inspector as overlay panels", async () =
     "utf8"
   );
 
-  assert.match(panelHook, /panel\.inert = mobile && !active/);
+  assert.match(panelHook, /panel\.inert = overlayOpen \? !active : drawer/);
   assert.match(panelHook, /event\.key === "Tab"/);
   assert.match(panelHook, /activeToggle\?\.focus\(\)/);
+});
+
+test("focus mode exposes the runtime hierarchy as a desktop drawer", () => {
+  const desktop = { matches: false };
+  const hook = { ...BeamConsolePanels, media: desktop, focusActive: true };
+
+  assert.equal(hook.panelIsDrawer("runtime"), true);
+  assert.equal(hook.panelIsDrawer("inspector"), false);
+
+  hook.focusActive = false;
+  assert.equal(hook.panelIsDrawer("runtime"), false);
 });
 
 test("mobile panels restore focus when dismissed", () => {
@@ -355,6 +366,7 @@ test("focus mode updates browser state without touching runtime controls", () =>
         writeStoredBoolean(window, "beam-console:focus:/beam", active);
       },
       syncFocusMode: () => { synced = true; },
+      syncPanels: () => {},
       scheduleWorkspaceResize: () => { resized = true; }
     };
 
@@ -394,6 +406,100 @@ test("storage-driven focus changes recover focus only from hidden chrome", () =>
     hook.activePanel = "inspector";
     hook.el.dataset.beamConsoleHasSelection = "true";
     assert.equal(hook.focusTransitionHidesActiveControl(true), true);
+    assert.equal(hook.focusTransitionHidesActiveControl(false), true);
+  } finally {
+    globalThis.document = previousDocument;
+  }
+});
+
+test("storage-driven focus exit closes drawers before restoring visible focus", () => {
+  const previousDocument = globalThis.document;
+  let closed = false;
+  let moveFocus = false;
+
+  globalThis.document = {
+    documentElement: { dataset: {} },
+    activeElement: { closest: () => null }
+  };
+
+  try {
+    const hook = {
+      ...BeamConsolePanels,
+      focusActive: true,
+      activePanel: "runtime",
+      el: { contains: () => true },
+      closePanels: () => {
+        closed = true;
+        hook.activePanel = null;
+      },
+      syncFocusMode: move => { moveFocus = move; },
+      syncPanels: () => {},
+      scheduleWorkspaceResize: () => {}
+    };
+    const focusMustMove = hook.focusTransitionHidesActiveControl(false);
+
+    hook.setFocusMode(false, false, focusMustMove, false);
+
+    assert.equal(closed, true);
+    assert.equal(moveFocus, true);
+    assert.equal(hook.activePanel, null);
+  } finally {
+    globalThis.document = previousDocument;
+  }
+});
+
+test("focus mode closes an inspector drawer when its selection disappears", () => {
+  const exit = {};
+  let closed = false;
+  const hook = {
+    ...BeamConsolePanels,
+    focusActive: true,
+    activePanel: "inspector",
+    returnFocus: null,
+    el: {
+      dataset: { beamConsoleHasSelection: "false" },
+      querySelector: selector => selector === "#beam-console-focus-exit" ? exit : null
+    },
+    syncFocusMode: () => {},
+    closePanels: () => { closed = true; }
+  };
+
+  hook.updated();
+
+  assert.equal(hook.returnFocus, exit);
+  assert.equal(closed, true);
+});
+
+test("a panel receiving focus becomes the active drawer at the mobile breakpoint", () => {
+  const runtimeToggle = {};
+  const focusedPanel = {
+    dataset: { beamConsolePanel: "runtime" }
+  };
+  const previousDocument = globalThis.document;
+  let focusedDrawer = false;
+
+  globalThis.document = {
+    activeElement: {
+      closest: selector => selector === "[data-beam-console-panel]" ? focusedPanel : null
+    }
+  };
+
+  try {
+    const hook = {
+      ...BeamConsolePanels,
+      media: { matches: true },
+      focusActive: false,
+      activePanel: null,
+      returnFocus: null,
+      panelToggle: () => runtimeToggle,
+      syncPanels: focusPanel => { focusedDrawer = focusPanel; }
+    };
+
+    hook.syncBreakpoint();
+
+    assert.equal(hook.activePanel, "runtime");
+    assert.equal(hook.returnFocus, runtimeToggle);
+    assert.equal(focusedDrawer, true);
   } finally {
     globalThis.document = previousDocument;
   }
@@ -475,7 +581,7 @@ test("header navigation keeps a fixed center column across tabs", async () => {
   assert.match(stylesheet, /\.beam-console-search-form\.is-placeholder\s*\{[\s\S]*?visibility:\s*hidden/);
 });
 
-test("focus mode removes chrome without changing the active workspace", async () => {
+test("focus mode provides a fixed workspace bar and hierarchy drawer", async () => {
   const stylesheet = await readFile(
     new URL("../../priv/static/beam_console.css", import.meta.url),
     "utf8"
@@ -498,7 +604,27 @@ test("focus mode removes chrome without changing the active workspace", async ()
   );
   assert.match(
     stylesheet,
-    /data-beam-console-focus="true"[\s\S]*?\.beam-console-focus-exit[\s\S]*?display:\s*grid/
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-focus-bar[\s\S]*?display:\s*flex/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-shell\s*\{[\s\S]*?height:\s*100dvh[\s\S]*?min-height:\s*0/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-focus-bar\s*\{[\s\S]*?grid-column:\s*1 \/ -1[\s\S]*?grid-row:\s*1/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-frame\s*\{[\s\S]*?height:\s*100dvh[\s\S]*?min-height:\s*0/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-sidebar[\s\S]*?position:\s*fixed[\s\S]*?transform:\s*translateX\(-105%\)/
+  );
+  assert.match(
+    stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-sidebar\.is-mobile-open[\s\S]*?transform:\s*translateX\(0\)/
   );
   assert.match(
     stylesheet,
@@ -506,11 +632,19 @@ test("focus mode removes chrome without changing the active workspace", async ()
   );
   assert.match(
     stylesheet,
+    /data-beam-console-focus="true"[\s\S]*?\.beam-console-focus-actions[\s\S]*?\.beam-console-focus-inspector\s*\{[\s\S]*?display:\s*none/
+  );
+  assert.match(
+    stylesheet,
     /data-beam-console-focus="true"[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) clamp\(280px, 32vw, 332px\)/
   );
   assert.match(
     stylesheet,
-    /@media \(max-width: 760px\)[\s\S]*?\.beam-console-main:not\(\.beam-console-tab-main\)[\s\S]*?grid-template-rows:\s*minmax\(0, 64dvh\) minmax\(0, 36dvh\)/
+    /@media \(max-width: 760px\)[\s\S]*?\.beam-console-main:not\(\.beam-console-tab-main\)[\s\S]*?grid-template-rows:\s*minmax\(0, 1\.8fr\) minmax\(0, 1fr\)/
+  );
+  assert.match(
+    stylesheet,
+    /@media \(max-width: 760px\)[\s\S]*?data-beam-console-has-selection="true"[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\)/
   );
   assert.match(
     stylesheet,

--- a/lib/beam_console_web/components/shell_components.ex
+++ b/lib/beam_console_web/components/shell_components.ex
@@ -150,6 +150,19 @@ if Code.ensure_loaded?(Phoenix.Component) do
           </button>
 
           <button
+            id="beam-console-refresh"
+            class={["beam-console-icon-button", @refresh_pending? && "is-pending"]}
+            phx-click="refresh"
+            aria-label="Refresh runtime sample"
+            data-tooltip="Refresh sample"
+            aria-busy={if(@refresh_pending?, do: "true", else: "false")}
+          >
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+            </svg>
+          </button>
+
+          <button
             id="beam-console-focus-mode"
             type="button"
             class="beam-console-icon-button"
@@ -161,19 +174,6 @@ if Code.ensure_loaded?(Phoenix.Component) do
           >
             <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
               <path d="M9 4H4v5M15 4h5v5M20 15v5h-5M4 15v5h5" />
-            </svg>
-          </button>
-
-          <button
-            id="beam-console-refresh"
-            class={["beam-console-icon-button", @refresh_pending? && "is-pending"]}
-            phx-click="refresh"
-            aria-label="Refresh runtime sample"
-            data-tooltip="Refresh sample"
-            aria-busy={if(@refresh_pending?, do: "true", else: "false")}
-          >
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
             </svg>
           </button>
 

--- a/lib/beam_console_web/console_live.ex
+++ b/lib/beam_console_web/console_live.ex
@@ -281,35 +281,56 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             aria-live="polite"
             aria-atomic="true"
           ></span>
-          <button
-            id="beam-console-focus-inspector"
-            type="button"
-            class="beam-console-icon-button beam-console-focus-inspector"
-            data-beam-console-panel-toggle="inspector"
-            aria-controls="beam-console-inspector-panel"
-            aria-expanded="false"
-            aria-label="Open inspector"
-            data-tooltip="Inspector"
-          >
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <circle cx="11" cy="11" r="6" />
-              <path d="m16 16 4 4M11 8v6M8 11h6" />
-            </svg>
-          </button>
-          <button
-            id="beam-console-focus-exit"
-            type="button"
-            class="beam-console-icon-button beam-console-focus-exit"
-            data-beam-console-focus-toggle
-            aria-label="Exit focus mode"
-            aria-keyshortcuts="Escape"
-            aria-pressed="false"
-            data-tooltip="Exit focus mode (Esc)"
-          >
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M4 9h5V4M20 9h-5V4M20 15h-5v5M4 15h5v5" />
-            </svg>
-          </button>
+          <div id="beam-console-focus-bar" class="beam-console-focus-bar">
+            <span class="beam-console-focus-label">Focus</span>
+            <div class="beam-console-focus-actions">
+              <button
+                id="beam-console-focus-runtime"
+                type="button"
+                class="beam-console-icon-button"
+                data-beam-console-panel-toggle="runtime"
+                aria-controls="beam-console-runtime-panel"
+                aria-expanded="false"
+                aria-label="Open runtime hierarchy"
+                data-tooltip="Runtime hierarchy"
+              >
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M4 6h6M4 12h10M4 18h16" />
+                  <circle cx="13" cy="6" r="2" />
+                  <circle cx="17" cy="12" r="2" />
+                </svg>
+              </button>
+              <button
+                id="beam-console-focus-inspector"
+                type="button"
+                class="beam-console-icon-button beam-console-focus-inspector"
+                data-beam-console-panel-toggle="inspector"
+                aria-controls="beam-console-inspector-panel"
+                aria-expanded="false"
+                aria-label="Open inspector"
+                data-tooltip="Inspector"
+              >
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <circle cx="11" cy="11" r="6" />
+                  <path d="m16 16 4 4M11 8v6M8 11h6" />
+                </svg>
+              </button>
+              <button
+                id="beam-console-focus-exit"
+                type="button"
+                class="beam-console-icon-button beam-console-focus-exit"
+                data-beam-console-focus-toggle
+                aria-label="Exit focus mode"
+                aria-keyshortcuts="Escape"
+                aria-pressed="false"
+                data-tooltip="Exit focus mode (Esc)"
+              >
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M4 9h5V4M20 9h-5V4M20 15h-5v5M4 15h5v5" />
+                </svg>
+              </button>
+            </div>
+          </div>
 
           <.runtime_tree
             nodes={@nodes}

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BeamConsole.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ccarvalho-eng/beam_console"
-  @version "0.5.1"
+  @version "0.5.2"
 
   def project do
     [

--- a/priv/static/beam_console.css
+++ b/priv/static/beam_console.css
@@ -408,8 +408,7 @@
 
 .beam-console-panel-toggle,
 .beam-console-panel-backdrop,
-.beam-console-focus-inspector,
-.beam-console-focus-exit {
+.beam-console-focus-bar {
   display: none;
 }
 .beam-console-visually-hidden {
@@ -1593,7 +1592,7 @@
     cursor: default;
   }
 
-  .beam-console-frame.has-mobile-panel .beam-console-panel-backdrop {
+  .beam-console-frame.has-overlay-panel .beam-console-panel-backdrop {
     display: block;
   }
 
@@ -1648,32 +1647,107 @@
 
 :root[data-beam-console-focus="true"] .beam-console-shell {
   height: 100dvh;
+  min-height: 0;
   padding: 0;
 }
 
 :root[data-beam-console-focus="true"] .beam-console-frame {
   position: relative;
+  display: grid;
   width: 100%;
   max-width: none;
   height: 100dvh;
-  min-height: 640px;
+  min-height: 0;
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, 1fr);
   border: 0;
   border-radius: 0;
   box-shadow: none;
 }
 
 :root[data-beam-console-focus="true"] .beam-console-header,
-:root[data-beam-console-focus="true"] .beam-console-sidebar,
 :root[data-beam-console-focus="true"] .beam-console-runtime-summary,
 :root[data-beam-console-focus="true"] .beam-console-recorder-summary {
   display: none;
 }
 
+:root[data-beam-console-focus="true"] .beam-console-focus-bar {
+  z-index: 30;
+  display: flex;
+  grid-column: 1 / -1;
+  grid-row: 1;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px 0 16px;
+  border-bottom: 1px solid var(--bc-border);
+  background: color-mix(in srgb, var(--bc-surface), var(--bc-surface-muted) 28%);
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-label {
+  color: var(--bc-muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-focus-actions .beam-console-icon-button {
+  display: grid;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-focus-actions
+  .beam-console-focus-inspector {
+  display: none;
+}
+
 :root[data-beam-console-focus="true"] .beam-console-main {
   grid-column: 1;
-  grid-row: 1;
+  grid-row: 2;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-sidebar {
+  position: fixed;
+  z-index: 40;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  display: block;
+  width: min(88vw, 360px);
+  border-right: 1px solid var(--bc-border);
+  box-shadow: 18px 0 42px rgb(15 23 42 / 22%);
+  transform: translateX(-105%);
+  transition: transform 160ms ease;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-sidebar.is-mobile-open {
+  transform: translateX(0);
+}
+
+:root[data-beam-console-focus="true"] .beam-console-sidebar .beam-console-panel-close {
+  display: inline-flex;
+}
+
+:root[data-beam-console-focus="true"] .beam-console-panel-backdrop {
+  position: fixed;
+  z-index: 35;
+  inset: 0;
+  border: 0;
+  background: rgb(15 23 42 / 42%);
+  cursor: default;
+}
+
+:root[data-beam-console-focus="true"]
+  .beam-console-frame.has-overlay-panel
+  .beam-console-panel-backdrop {
+  display: block;
 }
 
 :root[data-beam-console-focus="true"]
@@ -1692,26 +1766,10 @@
   .beam-console-inspector {
   display: block;
   grid-column: 2;
-  grid-row: 1;
+  grid-row: 2;
   min-height: 0;
   border-top: 0;
   border-left: 1px solid var(--bc-border);
-}
-
-:root[data-beam-console-focus="true"] .beam-console-focus-exit {
-  position: absolute;
-  z-index: 30;
-  top: 12px;
-  right: 12px;
-  display: grid;
-  background: color-mix(in srgb, var(--bc-surface), transparent 4%);
-  box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
-}
-
-:root[data-beam-console-focus="true"]
-  .beam-console-frame[data-beam-console-has-selection="true"]
-  .beam-console-focus-exit {
-  right: calc(clamp(280px, 32vw, 332px) + 12px);
 }
 
 @media (max-width: 760px) {
@@ -1721,13 +1779,18 @@
 
   :root[data-beam-console-focus="true"] .beam-console-main,
   :root[data-beam-console-focus="true"] .beam-console-tab-main {
-    height: 100dvh;
+    height: calc(100dvh - 48px);
     min-height: 0;
     flex: 1 1 auto;
   }
 
+  :root[data-beam-console-focus="true"]
+    .beam-console-frame[data-beam-console-has-selection="true"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   :root[data-beam-console-focus="true"] .beam-console-main:not(.beam-console-tab-main) {
-    grid-template-rows: minmax(0, 64dvh) minmax(0, 36dvh);
+    grid-template-rows: minmax(0, 1.8fr) minmax(0, 1fr);
   }
 
   :root[data-beam-console-focus="true"] .beam-console-graph-stage {
@@ -1736,11 +1799,6 @@
 
   :root[data-beam-console-focus="true"] .beam-console-graph {
     min-height: 0;
-  }
-
-  :root[data-beam-console-focus="true"]
-    .beam-console-frame[data-beam-console-has-selection="true"] {
-    display: flex;
   }
 
   :root[data-beam-console-focus="true"]
@@ -1760,19 +1818,7 @@
 
   :root[data-beam-console-focus="true"]
     .beam-console-frame[data-beam-console-has-selection="true"]
-    .beam-console-focus-exit {
-    right: 12px;
-  }
-
-  :root[data-beam-console-focus="true"]
-    .beam-console-frame[data-beam-console-has-selection="true"]
     .beam-console-focus-inspector {
-    position: absolute;
-    z-index: 30;
-    top: 12px;
-    right: 56px;
     display: grid;
-    background: color-mix(in srgb, var(--bc-surface), transparent 4%);
-    box-shadow: 0 2px 10px color-mix(in srgb, var(--bc-text), transparent 88%);
   }
 }

--- a/priv/static/beam_console.mjs
+++ b/priv/static/beam_console.mjs
@@ -181,8 +181,10 @@ const BeamConsolePanels = {
     this.focusReturn = null;
     this.togglePanel = event => {
       const toggle = event.target.closest("[data-beam-console-panel-toggle]");
-      if (!toggle || !this.media.matches) return;
+      if (!toggle) return;
       const name = toggle.dataset.beamConsolePanelToggle;
+      if (!this.panelIsDrawer(name)) return;
+
       if (this.activePanel === name) {
         this.closePanels();
         return;
@@ -218,10 +220,7 @@ const BeamConsolePanels = {
         this.setFocusMode(action === "toggle" ? !this.focusActive : false, true, true);
       }
     };
-    this.breakpointChanged = () => {
-      if (!this.media.matches) this.activePanel = null;
-      this.syncPanels(false);
-    };
+    this.breakpointChanged = () => this.syncBreakpoint();
     this.storageChanged = event => {
       if (event.key !== this.focusStorageKey) return;
       const active = this.readFocusPreference();
@@ -238,6 +237,17 @@ const BeamConsolePanels = {
   },
   updated() {
     this.syncFocusMode(false);
+
+    if (
+      this.focusActive &&
+      this.activePanel === "inspector" &&
+      this.el.dataset.beamConsoleHasSelection !== "true"
+    ) {
+      this.returnFocus = this.el.querySelector("#beam-console-focus-exit");
+      this.closePanels();
+      return;
+    }
+
     this.syncPanels(false);
   },
   destroyed() {
@@ -249,12 +259,14 @@ const BeamConsolePanels = {
     this.media.removeEventListener("change", this.breakpointChanged);
   },
   setFocusMode(active, persist, moveFocus, announce = persist) {
+    const changed = this.focusActive !== Boolean(active);
     this.focusActive = Boolean(active);
     document.documentElement.dataset.beamConsoleFocus = String(this.focusActive);
 
     if (persist) this.writeFocusPreference(this.focusActive);
-    if (this.focusActive && this.activePanel) this.closePanels();
+    if (changed && this.activePanel) this.closePanels();
     this.syncFocusMode(moveFocus, announce);
+    this.syncPanels(false);
     this.scheduleWorkspaceResize();
   },
   syncFocusMode(moveFocus, announce = false) {
@@ -281,7 +293,7 @@ const BeamConsolePanels = {
     if (active && this.activePanel) return true;
 
     if (!active) {
-      return Boolean(current.closest(".beam-console-focus-exit, .beam-console-focus-inspector"));
+      return Boolean(this.activePanel || current.closest(".beam-console-focus-bar"));
     }
 
     const selected = this.el.dataset.beamConsoleHasSelection === "true";
@@ -302,10 +314,37 @@ const BeamConsolePanels = {
   writeFocusPreference(active) {
     writeStoredBoolean(window, this.focusStorageKey, active);
   },
-  closePanels() {
-    const activeToggle = this.returnFocus || this.el.querySelector(
-      `[data-beam-console-panel-toggle="${this.activePanel}"]`
+  panelIsDrawer(name) {
+    return this.media.matches || (this.focusActive && name === "runtime");
+  },
+  panelToggle(name) {
+    const focusToggle = this.focusActive
+      ? this.el.querySelector(`#beam-console-focus-${name}`)
+      : null;
+
+    return focusToggle || this.el.querySelector(
+      `[data-beam-console-panel-toggle="${name}"]`
     );
+  },
+  syncBreakpoint() {
+    const focusedPanel = document.activeElement?.closest?.("[data-beam-console-panel]");
+    const focusedName = focusedPanel?.dataset.beamConsolePanel;
+
+    if (focusedName && this.panelIsDrawer(focusedName)) {
+      this.activePanel = focusedName;
+      this.returnFocus = this.panelToggle(focusedName);
+      this.syncPanels(true);
+      return;
+    }
+
+    if (this.activePanel && !this.panelIsDrawer(this.activePanel)) {
+      this.activePanel = null;
+    }
+
+    this.syncPanels(false);
+  },
+  closePanels() {
+    const activeToggle = this.returnFocus || this.panelToggle(this.activePanel);
     this.activePanel = null;
     this.returnFocus = null;
     this.syncPanels(false);
@@ -343,18 +382,19 @@ const BeamConsolePanels = {
     }
   },
   syncPanels(focusPanel) {
-    const mobile = this.media.matches;
-    const modalOpen = mobile && Boolean(this.activePanel);
+    const overlayOpen = Boolean(this.activePanel) && this.panelIsDrawer(this.activePanel);
 
     this.el.querySelectorAll("[data-beam-console-panel]").forEach(panel => {
-      const active = mobile && panel.dataset.beamConsolePanel === this.activePanel;
+      const name = panel.dataset.beamConsolePanel;
+      const drawer = this.panelIsDrawer(name);
+      const active = overlayOpen && name === this.activePanel;
       panel.classList.toggle("is-mobile-open", active);
-      panel.inert = mobile && !active;
+      panel.inert = overlayOpen ? !active : drawer;
 
       if (panel.inert) panel.setAttribute("inert", "");
       else panel.removeAttribute("inert");
 
-      if (mobile) panel.setAttribute("aria-hidden", String(!active));
+      if (overlayOpen || drawer) panel.setAttribute("aria-hidden", String(!active));
       else panel.removeAttribute("aria-hidden");
 
       if (active) {
@@ -374,17 +414,17 @@ const BeamConsolePanels = {
       );
       if (!background) return;
 
-      child.inert = modalOpen;
+      child.inert = overlayOpen;
       if (child.inert) child.setAttribute("inert", "");
       else child.removeAttribute("inert");
     });
 
     this.el.querySelectorAll("[data-beam-console-panel-toggle]").forEach(toggle => {
-      const active = mobile && toggle.dataset.beamConsolePanelToggle === this.activePanel;
+      const active = overlayOpen && toggle.dataset.beamConsolePanelToggle === this.activePanel;
       toggle.setAttribute("aria-expanded", String(active));
     });
 
-    this.el.classList.toggle("has-mobile-panel", modalOpen);
+    this.el.classList.toggle("has-overlay-panel", overlayOpen);
   }
 };
 

--- a/test/beam_console_web/console_live_test.exs
+++ b/test/beam_console_web/console_live_test.exs
@@ -54,17 +54,22 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
 
     assert has_element?(
              view,
-             "#beam-console-focus-mode + #beam-console-refresh + #beam-console-theme-switcher button[data-beam-console-theme='system']"
+             "#beam-console-refresh + #beam-console-focus-mode + #beam-console-theme-switcher button[data-beam-console-theme='system']"
            )
 
     assert has_element?(
              view,
-             "#beam-console-focus-exit[data-beam-console-focus-toggle][aria-pressed='false']"
+             "#beam-console-focus-bar #beam-console-focus-exit[data-beam-console-focus-toggle][aria-pressed='false']"
            )
 
     assert has_element?(
              view,
-             "#beam-console-focus-inspector[data-beam-console-panel-toggle='inspector'][aria-expanded='false']"
+             "#beam-console-focus-bar #beam-console-focus-runtime[data-beam-console-panel-toggle='runtime'][aria-expanded='false']"
+           )
+
+    assert has_element?(
+             view,
+             "#beam-console-focus-bar #beam-console-focus-inspector[data-beam-console-panel-toggle='inspector'][aria-expanded='false']"
            )
 
     assert has_element?(


### PR DESCRIPTION
## Summary

- move Focus controls into a dedicated full-width workspace bar
- expose the runtime hierarchy as an accessible drawer at every viewport width
- keep inspector visibility, mobile sizing, focus restoration, and breakpoint transitions coherent
- place Focus immediately before the theme switcher in the standard header

## Release

Prepares BeamConsole 0.5.2 with matching README, changelog, generated assets, and release metadata.