### PR TITLE
fix(console): show process selection context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.5.3 - 2026-08-28
+
+- Keep the selected process visible in the runtime sidebar and mark its owning application as selection context.
+
 ## 0.5.2 - 2026-08-28
 
 - Move Focus controls into a dedicated full-viewport bar so they never cover workspace headings.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add BeamConsole to a Phoenix application:
 ```elixir
 def deps do
   [
-    {:beam_console, "~> 0.5.2"}
+    {:beam_console, "~> 0.5.3"}
   ]
 end
 ```

--- a/assets/css/tree.css
+++ b/assets/css/tree.css
@@ -86,6 +86,47 @@
   text-transform: uppercase;
 }
 
+.beam-console-sidebar-selection {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--bc-border);
+  background: color-mix(in srgb, var(--bc-accent-soft), transparent 28%);
+}
+
+.beam-console-sidebar-selection-copy {
+  min-width: 0;
+}
+
+.beam-console-sidebar-selection-eyebrow {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--bc-accent);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.beam-console-sidebar-selection-label {
+  display: block;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.beam-console-sidebar-selection-pid {
+  flex: 0 0 auto;
+  color: var(--bc-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+}
+
 .beam-console-list {
   margin: 0;
   padding: 10px;
@@ -220,6 +261,15 @@
 
 .beam-console-link:hover {
   background: var(--bc-surface);
+}
+
+.beam-console-link.has-selected-process {
+  border-color: color-mix(in srgb, var(--bc-accent-border), transparent 35%);
+  background: var(--bc-accent-soft);
+}
+
+.beam-console-link.has-selected-process .beam-console-count {
+  color: var(--bc-accent);
 }
 
 .beam-console-link.is-selected {

--- a/assets/test/client-contracts.test.mjs
+++ b/assets/test/client-contracts.test.mjs
@@ -552,6 +552,22 @@ test("runtime summary adapts before cards become cramped", async () => {
   );
 });
 
+test("runtime tree distinguishes selected processes from selected applications", async () => {
+  const stylesheet = await readFile(
+    new URL("../../priv/static/beam_console.css", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(
+    stylesheet,
+    /\.beam-console-sidebar-selection\s*\{[\s\S]*?border-bottom:\s*1px solid var\(--bc-border\)/
+  );
+  assert.match(
+    stylesheet,
+    /\.beam-console-link\.has-selected-process\s*\{[\s\S]*?background:\s*var\(--bc-accent-soft\)/
+  );
+});
+
 test("tablet process diagnostics do not compete with relationship rows", async () => {
   const stylesheet = await readFile(
     new URL("../../priv/static/beam_console.css", import.meta.url),

--- a/lib/beam_console_web/components/tree_components.ex
+++ b/lib/beam_console_web/components/tree_components.ex
@@ -8,11 +8,17 @@ if Code.ensure_loaded?(Phoenix.Component) do
     attr(:categories, :list, required: true)
     attr(:application_count, :integer, required: true)
     attr(:selected_id, :string, default: nil)
+    attr(:selected, :map, default: nil)
     attr(:coverage_warnings, :list, default: [])
 
     @doc "Renders nodes and application categories as stable native disclosure branches."
     @spec runtime_tree(map()) :: Phoenix.LiveView.Rendered.t()
     def runtime_tree(assigns) do
+      assigns =
+        assigns
+        |> assign(:selected_process, selected_process(assigns.selected))
+        |> assign(:selected_application_id, selected_application_id(assigns.selected))
+
       ~H"""
       <aside
         id="beam-console-runtime-panel"
@@ -39,6 +45,21 @@ if Code.ensure_loaded?(Phoenix.Component) do
             </div>
           </div>
           <p>Nodes and categorized applications</p>
+        </div>
+
+        <div
+          :if={@selected_process}
+          id="beam-console-sidebar-selection"
+          class="beam-console-sidebar-selection"
+          data-selected-id={@selected_process.id}
+        >
+          <div class="beam-console-sidebar-selection-copy">
+            <span class="beam-console-sidebar-selection-eyebrow">Selected process</span>
+            <strong class="beam-console-sidebar-selection-label">{@selected_process.label}</strong>
+          </div>
+          <span class="beam-console-sidebar-selection-pid">
+            {@selected_process[:pid_text] || "vanished"}
+          </span>
         </div>
 
         <div :for={warning <- @coverage_warnings} class="beam-console-warning">{warning}</div>
@@ -91,14 +112,24 @@ if Code.ensure_loaded?(Phoenix.Component) do
                             id={"select-#{application.id}"}
                             class={[
                               "beam-console-link",
-                              @selected_id == application.id && "is-selected"
+                              @selected_id == application.id && "is-selected",
+                              @selected_application_id == application.id &&
+                                "has-selected-process"
                             ]}
                             phx-click="select_entity"
                             phx-value-id={application.id}
+                            data-selection-context={
+                              if(@selected_application_id == application.id, do: "process")
+                            }
                             aria-pressed={if(@selected_id == application.id, do: "true", else: "false")}
                           >
                             <span class="beam-console-link-label">{application.name}</span>
-                            <span class="beam-console-count">app</span>
+                            <span class="beam-console-count">
+                              {if(@selected_application_id == application.id,
+                                do: "process",
+                                else: "app"
+                              )}
+                            </span>
                           </button>
                         </li>
                       </ul>
@@ -126,6 +157,23 @@ if Code.ensure_loaded?(Phoenix.Component) do
         </ul>
       </aside>
       """
+    end
+
+    defp selected_process(%{kind: kind} = selected) when kind in [:process, :vanished] do
+      selected
+    end
+
+    defp selected_process(_selected) do
+      nil
+    end
+
+    defp selected_application_id(%{kind: kind, application_id: application_id})
+         when kind in [:process, :vanished] and is_binary(application_id) do
+      application_id
+    end
+
+    defp selected_application_id(_selected) do
+      nil
     end
   end
 end

--- a/lib/beam_console_web/console/dashboard_presenter.ex
+++ b/lib/beam_console_web/console/dashboard_presenter.ex
@@ -54,7 +54,7 @@ defmodule BeamConsoleWeb.Console.DashboardPresenter do
 
   def selection(%Snapshot{} = snapshot, selected_id) do
     case Map.get(snapshot.index, selected_id) do
-      {:process, _pid} -> process_selection(snapshot.processes[selected_id])
+      {:process, _pid} -> process_selection(snapshot, snapshot.processes[selected_id])
       {:application, _name} -> application_selection(snapshot.applications[selected_id])
       {:node, _name} -> node_selection(snapshot.nodes[selected_id])
       _other -> %{id: selected_id, kind: :unknown, label: "No longer available"}
@@ -71,18 +71,27 @@ defmodule BeamConsoleWeb.Console.DashboardPresenter do
     false
   end
 
-  defp process_selection(nil) do
+  defp process_selection(_snapshot, nil) do
     nil
   end
 
-  defp process_selection(process) do
+  defp process_selection(snapshot, process) do
     %{
       id: process.id,
       kind: :process,
       label: process.label,
       pid_text: process.pid_text,
-      status: process.status
+      status: process.status,
+      application_id: process_application_id(snapshot, process)
     }
+  end
+
+  defp process_application_id(snapshot, process) do
+    application_name = process.supervision_application || process.application
+
+    Enum.find_value(snapshot.applications, fn {_id, application} ->
+      if application.name == application_name, do: application.id
+    end)
   end
 
   defp application_selection(nil) do

--- a/lib/beam_console_web/console_live.ex
+++ b/lib/beam_console_web/console_live.ex
@@ -337,6 +337,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             categories={@application_categories}
             application_count={@application_count}
             selected_id={@selected_id}
+            selected={@selected}
             coverage_warnings={@coverage_warnings}
           />
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BeamConsole.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ccarvalho-eng/beam_console"
-  @version "0.5.2"
+  @version "0.5.3"
 
   def project do
     [

--- a/priv/static/beam_console.css
+++ b/priv/static/beam_console.css
@@ -510,6 +510,47 @@
   text-transform: uppercase;
 }
 
+.beam-console-sidebar-selection {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--bc-border);
+  background: color-mix(in srgb, var(--bc-accent-soft), transparent 28%);
+}
+
+.beam-console-sidebar-selection-copy {
+  min-width: 0;
+}
+
+.beam-console-sidebar-selection-eyebrow {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--bc-accent);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.beam-console-sidebar-selection-label {
+  display: block;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.beam-console-sidebar-selection-pid {
+  flex: 0 0 auto;
+  color: var(--bc-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+}
+
 .beam-console-list {
   margin: 0;
   padding: 10px;
@@ -644,6 +685,15 @@
 
 .beam-console-link:hover {
   background: var(--bc-surface);
+}
+
+.beam-console-link.has-selected-process {
+  border-color: color-mix(in srgb, var(--bc-accent-border), transparent 35%);
+  background: var(--bc-accent-soft);
+}
+
+.beam-console-link.has-selected-process .beam-console-count {
+  color: var(--bc-accent);
 }
 
 .beam-console-link.is-selected {

--- a/test/beam_console_web/console/dashboard_presenter_test.exs
+++ b/test/beam_console_web/console/dashboard_presenter_test.exs
@@ -29,6 +29,9 @@ defmodule BeamConsoleWeb.Console.DashboardPresenterTest do
 
     assert %{kind: :application, label: "sample"} =
              DashboardPresenter.selection(snapshot, application.id)
+
+    assert %{kind: :process, application_id: "app_1"} =
+             DashboardPresenter.selection(snapshot, first.id)
   end
 
   defp process(id, label) do
@@ -37,7 +40,8 @@ defmodule BeamConsoleWeb.Console.DashboardPresenterTest do
       node_id: "node_1",
       pid: self(),
       pid_text: "<0.1.0>",
-      label: label
+      label: label,
+      application: :sample
     }
   end
 end

--- a/test/beam_console_web/console_live_test.exs
+++ b/test/beam_console_web/console_live_test.exs
@@ -153,6 +153,34 @@ defmodule BeamConsoleWeb.ConsoleLiveTest do
     assert has_element?(view, "#beam-console-tab-process_map[aria-current='page']")
   end
 
+  test "shows process selection context in the runtime sidebar", %{snapshot: snapshot} do
+    {process, application} =
+      Enum.find_value(snapshot.processes, fn {_id, process} ->
+        application_name = process.supervision_application || process.application
+
+        case Enum.find(snapshot.applications, fn {_id, application} ->
+               application.name == application_name
+             end) do
+          {_id, application} -> {process, application}
+          nil -> nil
+        end
+      end)
+
+    {:ok, view, _html} =
+      live(build_conn(), "/beam?" <> URI.encode_query(%{"entity" => process.id}))
+
+    assert has_element?(
+             view,
+             "#beam-console-sidebar-selection[data-selected-id='#{process.id}']",
+             process.label
+           )
+
+    assert has_element?(
+             view,
+             "#select-#{application.id}.has-selected-process[data-selection-context='process']"
+           )
+  end
+
   test "loads an allowlisted process detail from a URL selection", %{snapshot: snapshot} do
     process = snapshot.processes |> Map.values() |> Enum.find(&Process.alive?(&1.pid))
 


### PR DESCRIPTION
## Summary

- Keep the currently selected process visible in the runtime sidebar.
- Mark the process owning application as contextual without conflating it with application selection.
- Release the fix as 0.5.3 with regression coverage and rebuilt embedded assets.

## Validation

- Full project quality and test gates pass.
- Client asset, documentation, and Hex package validation pass.